### PR TITLE
Add GitHub link to docs header

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -49,12 +49,37 @@
     }
 
     header {
+      position: relative;
       display: flex;
       align-items: end;
       justify-content: space-between;
       gap: 2rem;
       padding-block: clamp(3rem, 9vw, 7rem) 2rem;
       border-bottom: 2px solid color-mix(var(--syntax-string), transparent);
+    }
+
+    .github-link {
+      position: absolute;
+      top: 1rem;
+      right: 0;
+      display: inline-grid;
+      width: 2.75rem;
+      height: 2.75rem;
+      place-items: center;
+      border: 1px solid var(--page-border);
+      border-radius: 6px;
+      background: var(--syntax-background);
+      color: var(--syntax-foreground);
+    }
+
+    .github-link:hover {
+      border-color: currentColor;
+    }
+
+    .github-link svg {
+      width: 1.125rem;
+      height: 1.125rem;
+      stroke-width: 2;
     }
 
     h1,
@@ -393,6 +418,12 @@
 </head>
 <body>
   <header>
+    <a class="github-link" href="https://github.com/davatron5000/microlighter" aria-label="View MicroLighter on GitHub" title="View MicroLighter on GitHub">
+      <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"></path>
+        <path d="M9 18c-4.51 2-5-2-7-2"></path>
+      </svg>
+    </a>
     <h1>MicroLighter</h1>
     <div class="theme-controls">
       <label class="theme-control">
@@ -408,8 +439,20 @@
       </label>
       <div class="theme-actions">
         <button class="color-scheme-toggle" id="color-scheme-toggle" type="button" aria-label="Use light mode" title="Use light mode">
-          <i class="icon-sun" data-lucide="sun" aria-hidden="true"></i>
-          <i class="icon-moon" data-lucide="moon" aria-hidden="true"></i>
+          <svg class="icon-sun" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="4"></circle>
+            <path d="M12 2v2"></path>
+            <path d="M12 20v2"></path>
+            <path d="m4.93 4.93 1.41 1.41"></path>
+            <path d="m17.66 17.66 1.41 1.41"></path>
+            <path d="M2 12h2"></path>
+            <path d="M20 12h2"></path>
+            <path d="m6.34 17.66-1.41 1.41"></path>
+            <path d="m19.07 4.93-1.41 1.41"></path>
+          </svg>
+          <svg class="icon-moon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"></path>
+          </svg>
         </button>
         <button id="show-theme-code" type="button">Show code</button>
       </div>
@@ -793,7 +836,6 @@ jobs:
     <pre lang="css"><code id="theme-code"></code></pre>
   </dialog>
 
-  <script src="https://unpkg.com/lucide@0.468.0/dist/umd/lucide.min.js"></script>
   <script>
     const themeSelect = document.querySelector("#theme");
     const showThemeCode = document.querySelector("#show-theme-code");
@@ -824,7 +866,6 @@ jobs:
     themeSelect.value = themes.includes(currentTheme) ? currentTheme : "github";
     document.documentElement.dataset.syntaxTheme = themeSelect.value;
     setColorScheme(document.documentElement.dataset.colorScheme);
-    lucide.createIcons();
 
     themeSelect.addEventListener("change", event => {
       document.documentElement.dataset.syntaxTheme = event.target.value;


### PR DESCRIPTION
## Summary

- add an accessible GitHub repository link to the docs header
- inline the three Lucide SVG icons instead of loading the full icon library