### PR TITLE
Add git diff grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,10 @@ Bundled themes:
 ## Languages
 
 Grammars ship as ES modules in `src/grammars/` and are loaded on demand:
-`bash`, `css`, `go`, `html`, `javascript`, `json`, `markdown`, `python`, `ruby`,
-`rust`, `scss`, `typescript`, `yaml`. Common aliases (`js`, `ts`, `sh`, `yml`,
-`rb`, `md`, `sass`, `py`, `rs`, …) resolve automatically.
+`bash`, `css`, `git-diff`, `go`, `html`, `javascript`, `json`, `markdown`,
+`python`, `ruby`, `rust`, `scss`, `typescript`, `yaml`. Common aliases (`js`,
+`ts`, `sh`, `yml`, `rb`, `md`, `diff`, `patch`, `sass`, `py`, `rs`, …) resolve
+automatically.
 
 ## Build
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -800,6 +800,23 @@ const answer = 42 as const;
 await highlightAll();</code></pre>
     </section>
 
+    <section class="sample" aria-labelledby="git-diff-label">
+      <div class="sample-label">
+        <h2 id="git-diff-label">Git diff</h2>
+      </div>
+      <pre lang="git-diff"><code>diff --git a/src/index.js b/src/index.js
+index 5c96d8e..55c1324 100644
+--- a/src/index.js
++++ b/src/index.js
+@@ -5,6 +5,7 @@ export { highlight };
+ const aliases = {
++  diff: "git-diff",
+   golang: "go",
+-  htm: "html",
++  html: "html",
+ };</code></pre>
+    </section>
+
     <section class="sample" aria-labelledby="yaml-label">
       <div class="sample-label">
         <h2 id="yaml-label">YAML</h2>

--- a/src/grammars/git-diff.js
+++ b/src/grammars/git-diff.js
@@ -1,0 +1,25 @@
+export default {
+  scopeName: "source.diff",
+  patterns: [
+    {
+      match: "^(?:diff --git .+|index [0-9a-f]+\\.\\.[0-9a-f]+.*|(?:---|\\+\\+\\+) .+)$",
+      name: "meta.diff.header"
+    },
+    {
+      match: "^@@ .* @@.*$",
+      name: "constant.numeric.line-number.diff"
+    },
+    {
+      match: "^\\+(?!\\+\\+).*$",
+      name: "markup.inserted.diff"
+    },
+    {
+      match: "^-(?!---).*$",
+      name: "markup.deleted.diff"
+    },
+    {
+      match: "^(?:new file mode|deleted file mode|old mode|new mode|similarity index|dissimilarity index|rename from|rename to|copy from|copy to|Binary files .+ differ|GIT binary patch).*$",
+      name: "meta.diff.metadata"
+    }
+  ]
+};

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -10,6 +10,8 @@ export const highlight = (blocks, grammarFor, grammarsByScope) => {
 
   const categoryFor = scope => {
     if (/comment|markup\.quote/.test(scope)) return "comment";
+    if (/markup\.inserted/.test(scope)) return "inserted";
+    if (/markup\.deleted/.test(scope)) return "deleted";
     if (/constant\.character\.entity/.test(scope)) return "entity";
     if (/keyword\.control\.doctype/.test(scope)) return "doctype";
     if (/keyword\.control\.at-rule/.test(scope)) return "atrule";

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,13 @@ import { highlight } from "./highlight.js";
 export { highlight };
 
 const aliases = {
+  diff: "git-diff",
   golang: "go",
   htm: "html",
   js: "javascript",
   jsx: "javascript",
   md: "markdown",
+  patch: "git-diff",
   py: "python",
   rb: "ruby",
   rs: "rust",

--- a/src/themes/dracula.css
+++ b/src/themes/dracula.css
@@ -55,3 +55,7 @@
 ::highlight(tag) { color: var(--syntax-tag); }
 
 ::highlight(selector) { color: var(--syntax-selector); }
+
+::highlight(inserted) { color: var(--syntax-function); }
+
+::highlight(deleted) { color: var(--syntax-keyword); }

--- a/src/themes/github.css
+++ b/src/themes/github.css
@@ -77,3 +77,11 @@
 ::highlight(selector) {
   color: var(--syntax-selector);
 }
+
+::highlight(inserted) {
+  color: var(--syntax-tag);
+}
+
+::highlight(deleted) {
+  color: var(--syntax-keyword);
+}

--- a/src/themes/monokai.css
+++ b/src/themes/monokai.css
@@ -55,3 +55,7 @@
 ::highlight(tag) { color: var(--syntax-tag); }
 
 ::highlight(selector) { color: var(--syntax-selector); }
+
+::highlight(inserted) { color: var(--syntax-string); }
+
+::highlight(deleted) { color: var(--syntax-keyword); }

--- a/src/themes/night-owl.css
+++ b/src/themes/night-owl.css
@@ -55,3 +55,7 @@
 ::highlight(tag) { color: var(--syntax-tag); }
 
 ::highlight(selector) { color: var(--syntax-selector); }
+
+::highlight(inserted) { color: var(--syntax-string); }
+
+::highlight(deleted) { color: var(--syntax-keyword); }

--- a/src/themes/solarized-light.css
+++ b/src/themes/solarized-light.css
@@ -55,3 +55,7 @@
 ::highlight(tag) { color: var(--syntax-tag); }
 
 ::highlight(selector) { color: var(--syntax-selector); }
+
+::highlight(inserted) { color: var(--syntax-string); }
+
+::highlight(deleted) { color: var(--syntax-keyword); }

--- a/src/themes/vscode-plus.css
+++ b/src/themes/vscode-plus.css
@@ -77,3 +77,11 @@
 ::highlight(selector) {
   color: var(--syntax-selector);
 }
+
+::highlight(inserted) {
+  color: var(--syntax-function);
+}
+
+::highlight(deleted) {
+  color: var(--syntax-keyword);
+}

--- a/test/highlight.spec.pw.js
+++ b/test/highlight.spec.pw.js
@@ -35,6 +35,29 @@ test.describe("MicroLighter demo site (docs/index.html)", () => {
     }
   });
 
+  test("highlights inserted and deleted git diff lines", async ({ page }) => {
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    const diffHighlights = await page.evaluate(() => {
+      const linesFor = category => [...CSS.highlights.get(category) ?? []]
+        .filter(range => range.startContainer.parentElement?.closest("pre[lang='git-diff']"))
+        .map(range => range.toString());
+
+      return {
+        inserted: linesFor("inserted"),
+        deleted: linesFor("deleted"),
+        keywords: linesFor("keyword")
+      };
+    });
+
+    expect(diffHighlights.inserted).toEqual(expect.arrayContaining([
+      '+  diff: "git-diff",',
+      '+  html: "html",'
+    ]));
+    expect(diffHighlights.deleted).toContain('-  htm: "html",');
+    expect(diffHighlights.keywords).toEqual([]);
+  });
+
   test("re-highlights after switching themes via the syntax-highlight event", async ({ page }) => {
     await page.goto("/", { waitUntil: "networkidle" });
 


### PR DESCRIPTION
## What does this change?

Adds a lazily loaded Git diff grammar with `diff` and `patch` aliases, dedicated inserted/deleted highlight categories, theme support, and a demo fixture. Diff headers remain neutral while hunk markers and changed lines receive focused syntax colors.

## Checklist

- [x] `npm test` passes locally
- [x] The size budget still passes (note any size impact below)
- [x] Added/updated tests or the demo (`docs/index.html`) if behavior changed
- [x] For a new grammar/theme, followed the steps in `CONTRIBUTING.md`

## Size impact

`grammars/git-diff.js`: 0.67 KiB raw, 0.53 KiB minified, 0.30 KiB gzip. Main bundle remains 2.06 KiB gzip.