### PR TITLE
Simplify highlight lifecycle

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -4,9 +4,15 @@
  * @param {(code: HTMLElement) => Object | undefined} grammarFor
  * @param {Map<string, Object>} grammarsByScope
  */
+const highlights = new Map();
+
 export const highlight = (blocks, grammarFor, grammarsByScope) => {
-  const highlights = new Map();
   const regexes = new Map();
+
+  highlights.forEach((ranges, category) => {
+    if (CSS.highlights.get(category) === ranges) CSS.highlights.delete(category);
+    ranges.clear();
+  });
 
   const categoryFor = scope => {
     if (/comment|markup\.quote/.test(scope)) return "comment";
@@ -188,6 +194,6 @@ export const highlight = (blocks, grammarFor, grammarsByScope) => {
   });
 
   highlights.forEach((ranges, category) => {
-    CSS.highlights.set(category, ranges);
+    if (ranges.size) CSS.highlights.set(category, ranges);
   });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,5 @@
 import { highlight } from "./highlight.js";
 
-export { highlight };
-
 const aliases = {
   golang: "go",
   htm: "html",
@@ -86,8 +84,8 @@ const externalIncludesFor = (value, includes = new Set()) => {
  * @returns {Promise<HTMLElement[]>} The highlighted code elements.
  */
 export const highlightAll = async ({ root = document, selector = "pre[lang] > code" } = {}) => {
-  const blocks = () => [...root.querySelectorAll(selector)];
-  const languages = [...new Set(blocks().map(languageFor))]
+  const codeBlocks = [...root.querySelectorAll(selector)];
+  const languages = [...new Set(codeBlocks.map(languageFor))]
     .filter(language => /^[a-z0-9_-]+$/.test(language));
 
   let pendingLanguages = languages;
@@ -105,7 +103,6 @@ export const highlightAll = async ({ root = document, selector = "pre[lang] > co
   }));
   const grammars = Object.fromEntries(grammarEntries.filter(([, grammar]) => grammar));
 
-  const codeBlocks = blocks();
   highlight(codeBlocks, code => grammars[languageFor(code)], grammarsByScope);
   return codeBlocks;
 };

--- a/test/highlight.spec.pw.js
+++ b/test/highlight.spec.pw.js
@@ -53,6 +53,20 @@ test.describe("MicroLighter demo site (docs/index.html)", () => {
     expect(after.total).toBe(before.total);
   });
 
+  test("removes stale ranges when code blocks disappear", async ({ page }) => {
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    await page.evaluate(async () => {
+      document.querySelectorAll("pre[lang] > code").forEach(code => code.remove());
+      const { highlightAll } = await import("/microlighter/index.js");
+      await highlightAll();
+    });
+
+    const { categories, total } = await readHighlights(page);
+    expect(categories).toEqual([]);
+    expect(total).toBe(0);
+  });
+
   test("highlights every non-empty code block, including python, go, rust, and typescript", async ({ page }) => {
     await page.goto("/", { waitUntil: "networkidle" });
 


### PR DESCRIPTION
## Summary
- clear stale MicroLighter-owned highlight ranges between runs
- use one DOM snapshot per highlight pass
- keep the low-level tokenizer off the root export surface
- cover stale-range cleanup