### PR TITLE
Build matching bundle variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ automatically.
 
 ## Build
 
-Produce the distributable `dist/` folder (copied ESM source plus the minified
-single-file bundle `dist/microlighter.min.js`):
+Produce the distributable `dist/` folder (copied ESM modules plus unminified and
+minified single-file bundles at `dist/microlighter.js` and
+`dist/microlighter.min.js`):
 
 ```sh
 npm run build

--- a/build.sh
+++ b/build.sh
@@ -4,10 +4,8 @@ set -eu
 
 directory=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 dist="$directory/dist"
-bundle=$(mktemp "${TMPDIR:-/tmp}/microlighter.XXXXXX.js")
-output="$dist/microlighter.min.js"
-
-trap 'rm -f "$bundle"' EXIT
+bundle="$dist/microlighter.js"
+minified_bundle="$dist/microlighter.min.js"
 
 # Populate dist/ with the hand-authored ESM source (no transpile needed).
 rm -rf "$dist"
@@ -24,7 +22,7 @@ npx --yes terser@5.43.1 "$bundle" \
   --mangle \
   --module \
   --comments false \
-  --output "$output"
+  --output "$minified_bundle"
 
 # Vendor the built package into the docs/ site so GitHub Pages (source: /docs)
 # can serve a self-contained demo that loads the real distributable.

--- a/docs/index.html
+++ b/docs/index.html
@@ -472,7 +472,7 @@
       <article class="feature">
         <span class="feature-index" aria-hidden="true">02</span>
         <div class="feature-specimen size-specimen" aria-hidden="true">
-          <span class="size-value">2.09</span><span class="size-unit">kb<br>gzip</span>
+          <span class="size-value">2.12</span><span class="size-unit">kb<br>gzip</span>
         </div>
         <h2>Blazingly fast!!</h2>
       </article>

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "./build.sh",
     "size": "node scripts/report-size.mjs",
     "pretest": "./build.sh",
-    "test": "playwright test",
+    "test": "node --test test/*.spec.js && playwright test",
     "docs:update-homepage-stats": "./build.sh && node scripts/report-size.mjs --update-homepage",
     "prepack": "./build.sh"
   },

--- a/src/grammar-dependencies.js
+++ b/src/grammar-dependencies.js
@@ -1,0 +1,113 @@
+const aliases = {
+  diff: "git-diff",
+  golang: "go",
+  htm: "html",
+  js: "javascript",
+  jsx: "javascript",
+  md: "markdown",
+  patch: "git-diff",
+  py: "python",
+  rb: "ruby",
+  rs: "rust",
+  sass: "scss",
+  sh: "bash",
+  shell: "bash",
+  ts: "typescript",
+  tsx: "typescript",
+  yml: "yaml",
+  zsh: "bash"
+};
+
+/**
+ * Convert a supported language alias to its grammar module name.
+ * @param {string} language
+ * @returns {string}
+ */
+export const normalizeLanguage = language => aliases[language] || language;
+
+/**
+ * Find grammar modules referenced by external TextMate scope includes.
+ * Local repository references (`#...`, `$self`, and `$base`) are ignored.
+ * @param {*} value Grammar or nested grammar rule to inspect.
+ * @returns {Set<string>} Normalized grammar module names.
+ */
+export const externalLanguagesFor = value => {
+  const languages = new Set();
+
+  const visit = item => {
+    if (Array.isArray(item)) {
+      item.forEach(visit);
+    } else if (item && typeof item === "object") {
+      if (typeof item.include === "string" && !/^[#$]/.test(item.include)) {
+        const scope = item.include.split("#")[0];
+        const match = scope.match(/^(?:source|text)\.([a-z0-9_-]+)/);
+        if (match) languages.add(normalizeLanguage(match[1]));
+      }
+      Object.values(item).forEach(visit);
+    }
+  };
+
+  visit(value);
+  return languages;
+};
+
+/**
+ * Dynamically import a shipped grammar.
+ * @param {string} language
+ * @returns {Promise<Object | null>}
+ */
+const importGrammar = language => {
+  return import(`./grammars/${language}.js`)
+    .then(module => module.default)
+    .catch(() => null);
+};
+
+/**
+ * Create a cached loader that also resolves external grammar dependencies.
+ * @param {(language: string) => Promise<Object | null>} [importLanguage]
+ * @returns {(languages: string[]) => Promise<{
+ *   byLanguage: Object<string, Object>,
+ *   byScope: Map<string, Object>
+ * }>}
+ */
+export const createGrammarLoader = (importLanguage = importGrammar) => {
+  const grammarModules = new Map();
+  const grammars = {
+    byLanguage: {},
+    byScope: new Map()
+  };
+
+  /**
+   * Import and index a grammar once for the lifetime of this loader.
+   * @param {string} language
+   * @returns {Promise<Object | null>}
+   */
+  const loadGrammar = language => {
+    if (!grammarModules.has(language)) {
+      const grammarModule = importLanguage(language).then(grammar => {
+        if (grammar) {
+          grammars.byLanguage[language] = grammar;
+          grammars.byScope.set(grammar.scopeName, grammar);
+        }
+        return grammar;
+      });
+      grammarModules.set(language, grammarModule);
+    }
+
+    return grammarModules.get(language);
+  };
+
+  return async languages => {
+    let pendingLanguages = [...new Set(languages)]
+      .filter(language => !grammarModules.has(language));
+
+    while (pendingLanguages.length) {
+      const loadedGrammars = (await Promise.all(pendingLanguages.map(loadGrammar))).filter(Boolean);
+      pendingLanguages = [...new Set(loadedGrammars
+        .flatMap(grammar => [...externalLanguagesFor(grammar)]))]
+        .filter(language => !grammarModules.has(language));
+    }
+
+    return grammars;
+  };
+};

--- a/src/grammars/bash.js
+++ b/src/grammars/bash.js
@@ -1,3 +1,4 @@
+// Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/shellscript/syntaxes/shell-unix-bash.tmLanguage.json
 export default {
   scopeName: "source.shell",
   patterns: [

--- a/src/grammars/css.js
+++ b/src/grammars/css.js
@@ -1,3 +1,4 @@
+// Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/css/syntaxes/css.tmLanguage.json
 export default {
   scopeName: "source.css",
   patterns: [

--- a/src/grammars/git-diff.js
+++ b/src/grammars/git-diff.js
@@ -1,3 +1,4 @@
+// Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/diff/syntaxes/diff.tmLanguage.json
 export default {
   scopeName: "source.diff",
   patterns: [

--- a/src/grammars/go.js
+++ b/src/grammars/go.js
@@ -1,3 +1,4 @@
+// Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/go/syntaxes/go.tmLanguage.json
 export default {
   scopeName: "source.go",
   patterns: [

--- a/src/grammars/html.js
+++ b/src/grammars/html.js
@@ -1,3 +1,4 @@
+// Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/html/syntaxes/html.tmLanguage.json
 export default {
   scopeName: "text.html.basic",
   patterns: [

--- a/src/grammars/javascript.js
+++ b/src/grammars/javascript.js
@@ -1,3 +1,4 @@
+// Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/javascript/syntaxes/JavaScript.tmLanguage.json
 export default {
   scopeName: "source.js",
   patterns: [

--- a/src/grammars/json.js
+++ b/src/grammars/json.js
@@ -1,3 +1,4 @@
+// Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/json/syntaxes/JSON.tmLanguage.json
 export default {
   scopeName: "source.json",
   patterns: [

--- a/src/grammars/markdown.js
+++ b/src/grammars/markdown.js
@@ -1,3 +1,4 @@
+// Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json
 export default {
   scopeName: "text.html.markdown",
   patterns: [

--- a/src/grammars/python.js
+++ b/src/grammars/python.js
@@ -1,3 +1,4 @@
+// Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/python/syntaxes/MagicPython.tmLanguage.json
 export default {
   scopeName: "source.python",
   patterns: [

--- a/src/grammars/ruby.js
+++ b/src/grammars/ruby.js
@@ -1,3 +1,4 @@
+// Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/ruby/syntaxes/ruby.tmLanguage.json
 export default {
   scopeName: "source.ruby",
   patterns: [

--- a/src/grammars/rust.js
+++ b/src/grammars/rust.js
@@ -1,3 +1,4 @@
+// Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/rust/syntaxes/rust.tmLanguage.json
 export default {
   scopeName: "source.rust",
   patterns: [

--- a/src/grammars/scss.js
+++ b/src/grammars/scss.js
@@ -1,3 +1,4 @@
+// Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/scss/syntaxes/scss.tmLanguage.json
 export default {
   scopeName: "source.scss",
   patterns: [

--- a/src/grammars/typescript.js
+++ b/src/grammars/typescript.js
@@ -1,3 +1,4 @@
+// Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/typescript-basics/syntaxes/TypeScript.tmLanguage.json
 export default {
   scopeName: "source.ts",
   patterns: [

--- a/src/grammars/yaml.js
+++ b/src/grammars/yaml.js
@@ -1,3 +1,4 @@
+// Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/yaml/syntaxes/yaml.tmLanguage.json
 export default {
   scopeName: "source.yaml",
   patterns: [

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -1,11 +1,17 @@
 /**
- * Convert TextMate grammar matches into CSS Custom Highlight ranges.
- * @param {HTMLElement[]} blocks
- * @param {(code: HTMLElement) => Object | undefined} grammarFor
- * @param {Map<string, Object>} grammarsByScope
+ * Highlight sets retained between scans so stale registered ranges can be
+ * removed before replacements are created.
+ * @type {Map<string, Highlight>}
  */
 const highlights = new Map();
 
+/**
+ * Convert TextMate grammar matches into CSS Custom Highlight ranges.
+ * @param {HTMLElement[]} blocks Code elements containing one text node each.
+ * @param {(code: HTMLElement) => Object | undefined} grammarFor Grammar lookup.
+ * @param {Map<string, Object>} grammarsByScope External include lookup.
+ * @returns {void}
+ */
 export const highlight = (blocks, grammarFor, grammarsByScope) => {
   const regexes = new Map();
 
@@ -14,6 +20,11 @@ export const highlight = (blocks, grammarFor, grammarsByScope) => {
     ranges.clear();
   });
 
+  /**
+   * Map a TextMate scope to the smaller set of CSS highlight categories.
+   * @param {string} scope
+   * @returns {string | undefined}
+   */
   const categoryFor = scope => {
     if (/comment|markup\.quote/.test(scope)) return "comment";
     if (/markup\.inserted/.test(scope)) return "inserted";
@@ -44,6 +55,14 @@ export const highlight = (blocks, grammarFor, grammarsByScope) => {
     if (/entity|support/.test(scope)) return "symbol";
   };
 
+  /**
+   * Register a matched text span under its CSS highlight category.
+   * @param {Text} node
+   * @param {number} start
+   * @param {number} end
+   * @param {string} scope
+   * @returns {void}
+   */
   const addRange = (node, start, end, scope) => {
     const category = categoryFor(scope);
     if (!category || start === end) return;
@@ -56,6 +75,13 @@ export const highlight = (blocks, grammarFor, grammarsByScope) => {
     highlights.get(category).add(range);
   };
 
+  /**
+   * Add named capture-group spans from a TextMate rule match.
+   * @param {Text} node
+   * @param {RegExpExecArray} match
+   * @param {Object<string, {name: string}>} [captures]
+   * @returns {void}
+   */
   const addCaptures = (node, match, captures = {}) => {
     Object.entries(captures).forEach(([index, capture]) => {
       const offsets = match.indices[index];
@@ -63,11 +89,31 @@ export const highlight = (blocks, grammarFor, grammarsByScope) => {
     });
   };
 
+  /**
+   * Escape text before inserting it into a regular expression.
+   * @param {string} value
+   * @returns {string}
+   */
   const escapeRegex = value => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+  /**
+   * Replace TextMate end-pattern backreferences with escaped begin captures.
+   * @param {string} pattern
+   * @param {RegExpExecArray} beginMatch
+   * @returns {string}
+   */
   const expandEnd = (pattern, beginMatch) => pattern.replace(/\\(\d+)/g, (reference, index) => {
     return beginMatch[index] === undefined ? reference : escapeRegex(beginMatch[index]);
   });
 
+  /**
+   * Find the next bounded match while reusing compiled grammar expressions.
+   * @param {string} pattern
+   * @param {Text} node
+   * @param {number} start
+   * @param {number} end
+   * @returns {RegExpExecArray | null}
+   */
   const exec = (pattern, node, start, end) => {
     if (!regexes.has(pattern)) regexes.set(pattern, new RegExp(pattern, "dgm"));
     const regex = regexes.get(pattern);
@@ -76,6 +122,11 @@ export const highlight = (blocks, grammarFor, grammarsByScope) => {
     return match && match.indices[0][0] < end && match.indices[0][1] <= end ? match : null;
   };
 
+  /**
+   * Normalize a grammar rule or repository entry to a rule array.
+   * @param {*} rule
+   * @returns {Object[]}
+   */
   const rulesFor = rule => {
     if (!rule) return [];
     if (Array.isArray(rule)) return rule;
@@ -83,6 +134,13 @@ export const highlight = (blocks, grammarFor, grammarsByScope) => {
     return rule.patterns || [];
   };
 
+  /**
+   * Resolve local, base, and external TextMate include references.
+   * @param {string} include
+   * @param {Object} grammar
+   * @param {Object} baseGrammar
+   * @returns {{grammar: Object, rules: Object[]} | null}
+   */
   const resolveInclude = (include, grammar, baseGrammar) => {
     if (include === "$self") return { grammar, rules: grammar.patterns };
     if (include === "$base") return { grammar: baseGrammar, rules: baseGrammar.patterns };
@@ -103,6 +161,14 @@ export const highlight = (blocks, grammarFor, grammarsByScope) => {
     };
   };
 
+  /**
+   * Expand include rules into directly matchable rule contexts.
+   * @param {Object[]} rules
+   * @param {Object} grammar
+   * @param {Object} baseGrammar
+   * @param {Set<string>} [activeIncludes]
+   * @returns {{grammar: Object, rule: Object}[]}
+   */
   const expandRules = (rules, grammar, baseGrammar, activeIncludes = new Set()) => {
     const expanded = [];
 
@@ -126,6 +192,14 @@ export const highlight = (blocks, grammarFor, grammarsByScope) => {
     return expanded;
   };
 
+  /**
+   * Select the rule with the earliest match in a text region.
+   * @param {Text} node
+   * @param {{grammar: Object, rule: Object}[]} contexts
+   * @param {number} start
+   * @param {number} end
+   * @returns {{grammar: Object, rule: Object, match: RegExpExecArray} | null}
+   */
   const nextRule = (node, contexts, start, end) => {
     let winner = null;
 
@@ -142,6 +216,17 @@ export const highlight = (blocks, grammarFor, grammarsByScope) => {
     return winner;
   };
 
+  /**
+   * Scan a bounded text region, recursively handling begin/end rule pairs.
+   * @param {Text} node
+   * @param {Object[]} rules
+   * @param {number} start
+   * @param {number} end
+   * @param {Object} grammar
+   * @param {Object} [baseGrammar]
+   * @param {{pattern: string, applyEndPatternLast?: boolean} | null} [closing]
+   * @returns {{contentEnd: number, end: number, match: RegExpExecArray | null}}
+   */
   const scanRegion = (node, rules, start, end, grammar, baseGrammar = grammar, closing = null) => {
     const contexts = expandRules(rules, grammar, baseGrammar);
     let cursor = start;

--- a/src/index.js
+++ b/src/index.js
@@ -1,80 +1,16 @@
 import { highlight } from "./highlight.js";
+import { createGrammarLoader, normalizeLanguage } from "./grammar-dependencies.js";
 
-const aliases = {
-  diff: "git-diff",
-  golang: "go",
-  htm: "html",
-  js: "javascript",
-  jsx: "javascript",
-  md: "markdown",
-  patch: "git-diff",
-  py: "python",
-  rb: "ruby",
-  rs: "rust",
-  sass: "scss",
-  sh: "bash",
-  shell: "bash",
-  ts: "typescript",
-  tsx: "typescript",
-  yml: "yaml",
-  zsh: "bash"
-};
-
-const grammarModules = new Map();
-const grammarsByScope = new Map();
-
+/**
+ * Read and normalize the language declared by a code block's parent element.
+ * @param {HTMLElement} code
+ * @returns {string}
+ */
 const languageFor = code => {
-  const language = code.parentElement.lang.toLowerCase();
-  return aliases[language] || language;
+  return normalizeLanguage(code.parentElement.lang.toLowerCase());
 };
 
-/**
- * Convert a TextMate scope name to its grammar module filename.
- * @param {string} scope
- * @returns {string | null}
- */
-const languageForScope = scope => {
-  const match = scope.match(/^(?:source|text)\.([a-z0-9_-]+)/);
-  return match ? aliases[match[1]] || match[1] : null;
-};
-
-/**
- * Import and register a grammar once per page.
- * @param {string} language
- * @returns {Promise<Object | null>}
- */
-const loadGrammar = language => {
-  if (!grammarModules.has(language)) {
-    const grammarModule = import(`./grammars/${language}.js`)
-      .then(module => {
-        grammarsByScope.set(module.default.scopeName, module.default);
-        return module.default;
-      })
-      .catch(() => null);
-    grammarModules.set(language, grammarModule);
-  }
-
-  return grammarModules.get(language);
-};
-
-/**
- * Collect external scope includes from a grammar or repository rule.
- * @param {*} value
- * @param {Set<string>} includes
- * @returns {Set<string>}
- */
-const externalIncludesFor = (value, includes = new Set()) => {
-  if (Array.isArray(value)) {
-    value.forEach(item => externalIncludesFor(item, includes));
-  } else if (value && typeof value === "object") {
-    if (typeof value.include === "string" && !/^[#$]/.test(value.include)) {
-      includes.add(value.include.split("#")[0]);
-    }
-    Object.values(value).forEach(item => externalIncludesFor(item, includes));
-  }
-
-  return includes;
-};
+const loadGrammars = createGrammarLoader();
 
 /**
  * Scan the DOM for code blocks, lazily load the grammars they need, and
@@ -89,22 +25,8 @@ export const highlightAll = async ({ root = document, selector = "pre[lang] > co
   const codeBlocks = [...root.querySelectorAll(selector)];
   const languages = [...new Set(codeBlocks.map(languageFor))]
     .filter(language => /^[a-z0-9_-]+$/.test(language));
+  const grammars = await loadGrammars(languages);
 
-  let pendingLanguages = languages;
-  while (pendingLanguages.length) {
-    const loadedGrammars = (await Promise.all(pendingLanguages.map(loadGrammar))).filter(Boolean);
-    pendingLanguages = [...new Set(loadedGrammars
-      .flatMap(grammar => [...externalIncludesFor(grammar)])
-      .map(languageForScope)
-      .filter(Boolean))]
-      .filter(language => !grammarModules.has(language));
-  }
-
-  const grammarEntries = await Promise.all([...grammarModules].map(async ([language, grammarModule]) => {
-    return [language, await grammarModule];
-  }));
-  const grammars = Object.fromEntries(grammarEntries.filter(([, grammar]) => grammar));
-
-  highlight(codeBlocks, code => grammars[languageFor(code)], grammarsByScope);
+  highlight(codeBlocks, code => grammars.byLanguage[languageFor(code)], grammars.byScope);
   return codeBlocks;
 };

--- a/src/themes/dracula.css
+++ b/src/themes/dracula.css
@@ -1,3 +1,4 @@
+/* Reference: Dracula Theme (MIT) — https://github.com/dracula/visual-studio-code/blob/main/src/dracula.yml */
 [data-syntax-theme="dracula"] {
   --syntax-background: light-dark(#ffffff, #282a36);
   --syntax-foreground: light-dark(#282a36, #f8f8f2);

--- a/src/themes/github.css
+++ b/src/themes/github.css
@@ -1,3 +1,4 @@
+/* Reference: GitHub Primer (MIT) — https://github.com/primer/github-vscode-theme/blob/main/src/classic/colors.json */
 [data-syntax-theme="github"] {
   --syntax-background: light-dark(#ffffff, #0d1117);
   --syntax-foreground: light-dark(#24292f, #c9d1d9);

--- a/src/themes/index.css
+++ b/src/themes/index.css
@@ -1,3 +1,4 @@
+/* Attribution and pinned upstream references live in each imported theme. */
 @import "./github.css";
 @import "./vscode-plus.css";
 @import "./dracula.css";

--- a/src/themes/monokai.css
+++ b/src/themes/monokai.css
@@ -1,3 +1,4 @@
+/* Reference: VS Code Monokai (MIT; Monokai by Wimer Hazenberg) — https://github.com/microsoft/vscode/blob/main/extensions/theme-monokai/themes/monokai-color-theme.json */
 [data-syntax-theme="monokai"] {
   --syntax-background: light-dark(#ffffff, #272822);
   --syntax-foreground: light-dark(#272822, #f8f8f2);

--- a/src/themes/night-owl.css
+++ b/src/themes/night-owl.css
@@ -1,3 +1,4 @@
+/* Reference: Night Owl by Sarah Drasner (MIT) — https://github.com/sdras/night-owl-vscode-theme/blob/main/themes/Night%20Owl-color-theme.json */
 [data-syntax-theme="night-owl"] {
   --syntax-background: light-dark(#ffffff, #011627);
   --syntax-foreground: light-dark(#403f53, #d6deeb);

--- a/src/themes/solarized-light.css
+++ b/src/themes/solarized-light.css
@@ -1,3 +1,4 @@
+/* Reference: Solarized by Ethan Schoonover (MIT) — https://github.com/altercation/solarized/blob/master/textmate-colors-solarized/Solarized%20%28light%29.tmTheme */
 [data-syntax-theme="solarized-light"] {
   --syntax-background: light-dark(#fdf6e3, #002b36);
   --syntax-foreground: light-dark(#657b83, #93a1a1);

--- a/src/themes/vscode-plus.css
+++ b/src/themes/vscode-plus.css
@@ -1,3 +1,4 @@
+/* Reference: Microsoft VS Code Default Themes (MIT) — https://github.com/microsoft/vscode/tree/main/extensions/theme-defaults/themes */
 [data-syntax-theme="vscode-plus"] {
   --syntax-background: light-dark(#ffffff, #1e1e1e);
   --syntax-foreground: light-dark(#000000, #d4d4d4);

--- a/test/build.spec.js
+++ b/test/build.spec.js
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("build emits matching unminified and minified auto-run bundles", async () => {
+  const [bundle, minifiedBundle] = await Promise.all([
+    readFile(new URL("../dist/microlighter.js", import.meta.url), "utf8"),
+    readFile(new URL("../dist/microlighter.min.js", import.meta.url), "utf8")
+  ]);
+
+  assert.doesNotMatch(bundle, /from\s+["']\.\/index\.js["']/);
+  assert.match(bundle, /document\.addEventListener\(["']syntax-highlight["']/);
+  assert.match(minifiedBundle, /document\.addEventListener\(["']syntax-highlight["']/);
+  assert.ok(bundle.length > minifiedBundle.length);
+});

--- a/test/grammar-dependencies.spec.js
+++ b/test/grammar-dependencies.spec.js
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createGrammarLoader,
+  externalLanguagesFor,
+  normalizeLanguage
+} from "../src/grammar-dependencies.js";
+import html from "../src/grammars/html.js";
+import markdown from "../src/grammars/markdown.js";
+import scss from "../src/grammars/scss.js";
+import typescript from "../src/grammars/typescript.js";
+
+test("finds external grammar languages in nested rules", () => {
+  const grammar = {
+    patterns: [
+      { include: "#comments" },
+      { include: "$self" },
+      { include: "source.js#strings" }
+    ],
+    repository: {
+      frontMatter: {
+        patterns: [
+          { include: "source.yaml" },
+          { include: "source.js#comments" }
+        ]
+      }
+    }
+  };
+
+  assert.deepEqual([...externalLanguagesFor(grammar)], ["javascript", "yaml"]);
+});
+
+test("recognizes source and text scopes but ignores unsupported includes", () => {
+  const grammar = {
+    patterns: [
+      { include: "text.html#tags" },
+      { include: "source.css" },
+      { include: "meta.embedded.block" }
+    ]
+  };
+
+  assert.deepEqual([...externalLanguagesFor(grammar)], ["html", "css"]);
+});
+
+test("normalizes language aliases and preserves canonical names", () => {
+  assert.equal(normalizeLanguage("js"), "javascript");
+  assert.equal(normalizeLanguage("yml"), "yaml");
+  assert.equal(normalizeLanguage("python"), "python");
+});
+
+test("reports dependencies used by the shipped grammars", () => {
+  assert.deepEqual([...externalLanguagesFor(scss)], ["css"]);
+  assert.deepEqual([...externalLanguagesFor(markdown)], ["yaml"]);
+  assert.deepEqual([...externalLanguagesFor(typescript)], ["javascript"]);
+  assert.deepEqual([...externalLanguagesFor(html)], ["css", "json", "javascript"]);
+});
+
+test("loads external dependencies once and indexes grammars by language and scope", async () => {
+  const grammarFixtures = {
+    html: {
+      scopeName: "text.html",
+      patterns: [{ include: "source.js" }]
+    },
+    javascript: {
+      scopeName: "source.js",
+      patterns: []
+    }
+  };
+  const importedLanguages = [];
+  const load = createGrammarLoader(async language => {
+    importedLanguages.push(language);
+    return grammarFixtures[language] ?? null;
+  });
+
+  const loaded = await load(["html"]);
+  await load(["html"]);
+
+  assert.deepEqual(importedLanguages, ["html", "javascript"]);
+  assert.deepEqual(loaded.byLanguage, grammarFixtures);
+  assert.equal(loaded.byScope.get("text.html"), grammarFixtures.html);
+  assert.equal(loaded.byScope.get("source.js"), grammarFixtures.javascript);
+});

--- a/test/highlight.spec.pw.js
+++ b/test/highlight.spec.pw.js
@@ -79,15 +79,15 @@ test.describe("MicroLighter demo site (docs/index.html)", () => {
   test("removes stale ranges when code blocks disappear", async ({ page }) => {
     await page.goto("/", { waitUntil: "networkidle" });
 
-    await page.evaluate(async () => {
+    await page.evaluate(() => {
       document.querySelectorAll("pre[lang] > code").forEach(code => code.remove());
-      const { highlightAll } = await import("/microlighter/index.js");
-      await highlightAll();
+      document.dispatchEvent(new Event("syntax-highlight"));
     });
 
-    const { categories, total } = await readHighlights(page);
-    expect(categories).toEqual([]);
-    expect(total).toBe(0);
+    await expect.poll(() => readHighlights(page)).toMatchObject({
+      categories: [],
+      total: 0
+    });
   });
 
   test("highlights every non-empty code block, including python, go, rust, and typescript", async ({ page }) => {


### PR DESCRIPTION
## Summary
- emit dist/microlighter.js as the readable Rollup bundle and minify that same output
- extract and test cached grammar dependency loading
- document tokenizer internals and add upstream grammar/theme attribution

## Tests
- npm test