### PR TITLE
Support standard language markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,22 @@ highlight registry and CSS.
 ## Usage
 
 MicroLighter ships in three flavors so you can pick the right trade-off between
-convenience and control. In every case, mark up code blocks with a `lang`
-attribute on the `<pre>`:
+convenience and control. Use the HTML-standard `language-*` class on `<code>`:
 
 ```html
-<pre lang="javascript"><code>const answer = 42;</code></pre>
+<pre><code class="language-javascript">const answer = 42;</code></pre>
 ```
+
+MicroLighter also accepts `data-language="javascript"` on either `<code>` or
+its parent `<pre>`. The older `<pre lang="javascript">` form remains supported
+for compatibility but is deprecated because HTML's `lang` attribute describes
+human language.
 
 ### 1. Auto (drop-in)
 
 The auto-run entry (`microlighter/microlighter.js`, or the minified
 `microlighter/microlighter.min.js`) runs on import: it scans the page for
-`pre[lang] > code`, lazily imports only the grammars it needs, tokenizes each
+supported `<pre> > <code>` block, lazily imports only the grammars it needs, tokenizes each
 block, registers ranges with `CSS.highlights`, and re-highlights whenever a
 `syntax-highlight` event fires.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -557,15 +557,15 @@
         <h2 id="install-label">Install</h2>
       </div>
       <div class="install-steps">
-        <p>Add MicroLighter to your project, import a theme, then highlight every <code>pre[lang] &gt; code</code> block on the page.</p>
+        <p>Add MicroLighter to your project, import a theme, then mark each code block with a <code>language-*</code> class.</p>
         <pre><code>npm install microlighter</code></pre>
-        <pre lang="javascript"><code>import { highlightAll } from "microlighter";
+        <pre><code class="language-javascript">import { highlightAll } from "microlighter";
 import "microlighter/themes/github.css";
 
 await highlightAll();</code></pre>
-        <pre lang="html"><code>&lt;pre lang="javascript"&gt;&lt;code&gt;const answer = 42;&lt;/code&gt;&lt;/pre&gt;</code></pre>
+        <pre><code class="language-html">&lt;pre&gt;&lt;code class="language-javascript"&gt;const answer = 42;&lt;/code&gt;&lt;/pre&gt;</code></pre>
         <p>Prefer automatic setup? Import the minified auto-runner instead. It highlights the page immediately and re-highlights when a <code>syntax-highlight</code> event is dispatched.</p>
-        <pre lang="javascript"><code>import "microlighter/microlighter.min.js";</code></pre>
+        <pre><code class="language-javascript">import "microlighter/microlighter.min.js";</code></pre>
         <a href="https://github.com/davatron5000/microlighter#readme">Read more in the docs</a>
       </div>
     </section>
@@ -579,7 +579,7 @@ await highlightAll();</code></pre>
       <div class="sample-label">
         <h2 id="markup-label">Markup</h2>
       </div>
-      <pre lang="html"><code>&lt;!-- Nested CSS and JS get highlighted inside HTML --&gt;
+      <pre><code class="language-html">&lt;!-- Nested CSS and JS get highlighted inside HTML --&gt;
 &lt;syntax-card data-syntax-theme="vscode-plus"&gt;
   &lt;template shadowrootmode="open"&gt;
     &lt;style&gt;
@@ -615,7 +615,7 @@ await highlightAll();</code></pre>
       <div class="sample-label">
         <h2 id="css-label">CSS</h2>
       </div>
-      <pre lang="css"><code>/* Load every bundled theme, then pick one on <html> */
+      <pre><code class="language-css">/* Load every bundled theme, then pick one on <html> */
 @import "microlighter/themes/index.css";
 
 /* Themes only paint the code blocks, not the whole page */
@@ -639,7 +639,7 @@ pre:has(code) {
       <div class="sample-label">
         <h2 id="go-label">Go</h2>
       </div>
-      <pre lang="go"><code>package highlight
+      <pre><code class="language-go">package highlight
 
 import "fmt"
 
@@ -667,7 +667,7 @@ func Tokenize(source string, scopes []string) ([]Token, error) {
       <div class="sample-label">
         <h2 id="javascript-label">JavaScript</h2>
       </div>
-      <pre lang="javascript"><code>/* Side-effect-free API: highlight when you're ready */
+      <pre><code class="language-javascript">/* Side-effect-free API: highlight when you're ready */
 import { highlightAll } from "microlighter";
 
 await highlightAll();
@@ -686,7 +686,7 @@ async function addSnippet(container, markup) {
       <div class="sample-label">
         <h2 id="json-label">JSON</h2>
       </div>
-      <pre lang="json"><code>{
+      <pre><code class="language-json">{
   "name": "microlighter",
   "version": "1.0.0",
   "type": "module",
@@ -702,7 +702,7 @@ async function addSnippet(container, markup) {
       <div class="sample-label">
         <h2 id="markdown-label">Markdown</h2>
       </div>
-      <pre lang="markdown"><code>---
+      <pre><code class="language-markdown">---
 title: MicroLighter
 layout: doc
 ---
@@ -726,7 +726,7 @@ and grammars are lazy-loaded on demand.
       <div class="sample-label">
         <h2 id="python-label">Python</h2>
       </div>
-      <pre lang="python"><code>from dataclasses import dataclass
+      <pre><code class="language-python">from dataclasses import dataclass
 
 
 @dataclass
@@ -754,24 +754,16 @@ if __name__ == "__main__":
       <div class="sample-label">
         <h2 id="ruby-label">Ruby</h2>
       </div>
-      <pre lang="ruby"><code># Jekyll hook: MicroLighter was extracted from a Jekyll site.
-# Rewrite fenced code blocks to carry a `lang` attribute so
-# MicroLighter can highlight them on the client.
-Jekyll::Hooks.register :documents, :post_render do |doc|
-  next unless doc.output_ext == ".html"
-
-  doc.output = doc.output.gsub(
-    /&lt;pre&gt;&lt;code class="language-(\w+)"&gt;/,
-    '&lt;pre lang="\1"&gt;&lt;code&gt;'
-  )
-end</code></pre>
+      <pre><code class="language-ruby"># CommonMark and Kramdown fenced code blocks already emit
+# &lt;code class="language-ruby"&gt;, so no Jekyll hook is needed.
+puts "MicroLighter reads the generated language class"</code></pre>
     </section>
 
     <section class="sample" aria-labelledby="rust-label">
       <div class="sample-label">
         <h2 id="rust-label">Rust</h2>
       </div>
-      <pre lang="rust"><code>use std::collections::HashMap;
+      <pre><code class="language-rust">use std::collections::HashMap;
 
 /// A scoped span of source text.
 #[derive(Debug, Clone)]
@@ -803,7 +795,7 @@ fn tokenize&lt;'a&gt;(source: &amp;'a str, scopes: &amp;[&amp;'a str]) -> Result
       <div class="sample-label">
         <h2 id="scss-label">SCSS</h2>
       </div>
-      <pre lang="scss"><code>// Author a MicroLighter theme from a token map
+      <pre><code class="language-scss">// Author a MicroLighter theme from a token map
 $tokens: (
   background: #011627,
   foreground: #d6deeb,
@@ -826,7 +818,7 @@ $tokens: (
       <div class="sample-label">
         <h2 id="shell-label">Shell</h2>
       </div>
-      <pre lang="bash"><code>#!/usr/bin/env bash
+      <pre><code class="language-bash">#!/usr/bin/env bash
 set -euo pipefail
 
 # Build the dist/ bundle and print a size report
@@ -843,7 +835,7 @@ npm run docs:update-homepage-stats</code></pre>
       <div class="sample-label">
         <h2 id="typescript-label">TypeScript</h2>
       </div>
-      <pre lang="typescript"><code>import { highlightAll } from "microlighter";
+      <pre><code class="language-typescript">import { highlightAll } from "microlighter";
 
 /** A scoped span of source text. */
 interface Token&lt;T = string&gt; {
@@ -883,7 +875,7 @@ await highlightAll();</code></pre>
       <div class="sample-label">
         <h2 id="git-diff-label">Git diff</h2>
       </div>
-      <pre lang="git-diff"><code>diff --git a/src/index.js b/src/index.js
+      <pre><code class="language-git-diff">diff --git a/src/index.js b/src/index.js
 index 5c96d8e..55c1324 100644
 --- a/src/index.js
 +++ b/src/index.js
@@ -900,7 +892,7 @@ index 5c96d8e..55c1324 100644
       <div class="sample-label">
         <h2 id="yaml-label">YAML</h2>
       </div>
-      <pre lang="yaml"><code># .github/workflows/ci.yml
+      <pre><code class="language-yaml"># .github/workflows/ci.yml
 name: CI
 
 on:
@@ -929,7 +921,7 @@ jobs:
       <h2 id="theme-code-title">Theme code</h2>
       <button id="close-theme-code" type="button">Close</button>
     </div>
-    <pre lang="css"><code id="theme-code"></code></pre>
+    <pre><code class="language-css" id="theme-code"></code></pre>
   </dialog>
 
   <script>

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,27 @@
 import { highlight } from "./highlight.js";
 import { createGrammarLoader, normalizeLanguage } from "./grammar-dependencies.js";
 
+const languageClassFor = element => [...element.classList]
+  .find(className => className.startsWith("language-"))
+  ?.slice("language-".length);
+
 /**
- * Read and normalize the language declared by a code block's parent element.
+ * Read and normalize the language declared by a code block.
  * @param {HTMLElement} code
  * @returns {string}
  */
 const languageFor = code => {
-  return normalizeLanguage(code.parentElement.lang.toLowerCase());
-};
+  const pre = code.parentElement;
+  const language = languageClassFor(code)
+    || code.dataset.language
+    || languageClassFor(pre)
+    || pre.dataset.language
+    // Deprecated: `lang` describes human language, not programming language.
+    || pre.getAttribute("lang")
+    || "";
 
+  return normalizeLanguage(language.toLowerCase());
+};
 const loadGrammars = createGrammarLoader();
 
 /**
@@ -18,11 +30,11 @@ const loadGrammars = createGrammarLoader();
  *
  * @param {Object} [options]
  * @param {ParentNode} [options.root=document] Root to query within.
- * @param {string} [options.selector="pre[lang] > code"] Code block selector.
+ * @param {string} [options.selector] Code block selector.
  * @returns {Promise<HTMLElement[]>} The highlighted code elements.
  */
-export const highlightAll = async ({ root = document, selector = "pre[lang] > code" } = {}) => {
-  const codeBlocks = [...root.querySelectorAll(selector)];
+export const highlightAll = async ({ root = document, selector = "pre > code" } = {}) => {
+  const codeBlocks = [...root.querySelectorAll(selector)].filter(languageFor);
   const languages = [...new Set(codeBlocks.map(languageFor))]
     .filter(language => /^[a-z0-9_-]+$/.test(language));
   const grammars = await loadGrammars(languages);

--- a/test/highlight.spec.pw.js
+++ b/test/highlight.spec.pw.js
@@ -10,7 +10,7 @@ const readHighlights = page =>
     return {
       categories: [...CSS.highlights.keys()].sort(),
       total,
-      blocks: document.querySelectorAll("pre[lang] > code").length
+      blocks: document.querySelectorAll("pre > code[class*='language-']").length
     };
   });
 
@@ -40,7 +40,7 @@ test.describe("MicroLighter demo site (docs/index.html)", () => {
 
     const diffHighlights = await page.evaluate(() => {
       const linesFor = category => [...CSS.highlights.get(category) ?? []]
-        .filter(range => range.startContainer.parentElement?.closest("pre[lang='git-diff']"))
+        .filter(range => range.startContainer.parentElement?.closest("code.language-git-diff"))
         .map(range => range.toString());
 
       return {
@@ -80,7 +80,7 @@ test.describe("MicroLighter demo site (docs/index.html)", () => {
     await page.goto("/", { waitUntil: "networkidle" });
 
     await page.evaluate(() => {
-      document.querySelectorAll("pre[lang] > code").forEach(code => code.remove());
+      document.querySelectorAll("pre > code").forEach(code => code.remove());
       document.dispatchEvent(new Event("syntax-highlight"));
     });
 
@@ -97,24 +97,58 @@ test.describe("MicroLighter demo site (docs/index.html)", () => {
       const highlighted = new Set();
       for (const highlight of CSS.highlights.values()) {
         for (const range of highlight) {
-          const code = range.startContainer.parentElement?.closest("pre[lang] > code");
+          const code = range.startContainer.parentElement?.closest("pre > code");
           if (code) highlighted.add(code);
         }
       }
 
-      const blocks = [...document.querySelectorAll("pre[lang] > code")]
+      const blocks = [...document.querySelectorAll("pre > code[class*='language-']")]
         .filter(code => code.textContent.trim().length > 0);
 
       return {
-        langs: [...new Set(blocks.map(code => code.parentElement.getAttribute("lang")))],
+        langs: [...new Set(blocks.map(code => [...code.classList]
+          .find(className => className.startsWith("language-"))
+          .slice("language-".length)))],
         unhighlighted: blocks
           .filter(code => !highlighted.has(code))
-          .map(code => code.parentElement.getAttribute("lang"))
+          .map(code => code.className)
       };
     });
 
     expect(langs).toEqual(expect.arrayContaining(["python", "go", "rust", "typescript"]));
     expect(unhighlighted).toEqual([]);
+  });
+
+  test("supports standard classes, data attributes, and deprecated lang attributes", async ({ page }) => {
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    const highlighted = await page.evaluate(async () => {
+      const fixtures = [
+        '<pre><code id="class-language" class="example language-js">const classValue = true;</code></pre>',
+        '<pre><code id="code-data-language" data-language="json">{"code": true}</code></pre>',
+        '<pre data-language="python"><code id="pre-data-language">value = True</code></pre>',
+        '<pre lang="ruby"><code id="legacy-lang">legacy = true</code></pre>'
+      ];
+      document.body.insertAdjacentHTML("beforeend", fixtures.join(""));
+      document.dispatchEvent(new Event("syntax-highlight"));
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const ids = new Set();
+      for (const highlight of CSS.highlights.values()) {
+        for (const range of highlight) {
+          const id = range.startContainer.parentElement?.closest("code")?.id;
+          if (id) ids.add(id);
+        }
+      }
+      return [...ids];
+    });
+
+    expect(highlighted).toEqual(expect.arrayContaining([
+      "class-language",
+      "code-data-language",
+      "pre-data-language",
+      "legacy-lang"
+    ]));
   });
 
   test("loads without runtime errors", async ({ page }) => {


### PR DESCRIPTION
## Summary
- support standard `language-*` classes and `data-language` attributes
- retain `<pre lang>` as a deprecated compatibility path
- migrate documentation and demo markup to the standard convention
- add browser coverage for every supported language declaration