### PR TITLE
Add popular syntax themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Bundled themes:
 - `monokai`
 - `night-owl`
 - `solarized-light`
+- `vesper`
+- `min`
+- `cobalt2`
+- `tokyo-night`
 
 ## Languages
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -491,6 +491,10 @@
           <option value="monokai">Monokai</option>
           <option value="night-owl">Night Owl</option>
           <option value="solarized-light">Solarized</option>
+          <option value="vesper">Vesper</option>
+          <option value="min">Min</option>
+          <option value="cobalt2">Cobalt2</option>
+          <option value="tokyo-night">Tokyo Night</option>
         </select>
       </label>
       <div class="theme-actions">

--- a/src/themes/cobalt2.css
+++ b/src/themes/cobalt2.css
@@ -1,25 +1,25 @@
-/* Reference: Solarized by Ethan Schoonover (MIT) — https://github.com/altercation/solarized/blob/master/textmate-colors-solarized/Solarized%20%28light%29.tmTheme */
-[data-syntax-theme="solarized-light"] {
-  --syntax-background: light-dark(#fdf6e3, #002b36);
-  --syntax-foreground: light-dark(#657b83, #93a1a1);
-  --syntax-comment: light-dark(#93a1a1, #586e75);
-  --syntax-keyword: light-dark(#859900, #b8c927);
-  --syntax-operator: light-dark(#859900, #b8c927);
-  --syntax-string: light-dark(#2aa198, #58c7bd);
-  --syntax-constant: light-dark(#d33682, #e26aa5);
-  --syntax-function: light-dark(#268bd2, #5eb7e5);
-  --syntax-type: light-dark(#b58900, #d9b72f);
-  --syntax-variable: light-dark(#657b83, #93a1a1);
-  --syntax-property: light-dark(#268bd2, #5eb7e5);
-  --syntax-tag: light-dark(#268bd2, #5eb7e5);
-  --syntax-selector: light-dark(#268bd2, #5eb7e5);
-  --syntax-inserted: light-dark(#2aa198, #58c7bd);
-  --syntax-deleted: light-dark(#859900, #b8c927);
+/* Reference: Cobalt2 by Wes Bos (MIT) — https://github.com/wesbos/cobalt2-vscode/blob/master/theme/cobalt2.json */
+[data-syntax-theme="cobalt2"] {
+  --syntax-background: light-dark(#ffffff, #193549);
+  --syntax-foreground: light-dark(#193549, #ffffff);
+  --syntax-comment: light-dark(#006bbf, #0088ff);
+  --syntax-keyword: light-dark(#b85a00, #ff9d00);
+  --syntax-operator: light-dark(#7a6900, #ffee80);
+  --syntax-string: light-dark(#287a15, #a5ff90);
+  --syntax-constant: light-dark(#c51f5d, #ff628c);
+  --syntax-function: light-dark(#9b6500, #ffc600);
+  --syntax-type: light-dark(#b70068, #ff68b8);
+  --syntax-variable: light-dark(#193549, #e1efff);
+  --syntax-property: light-dark(#007878, #9effff);
+  --syntax-tag: light-dark(#007878, #9effff);
+  --syntax-selector: light-dark(#287a15, #3ad900);
+  --syntax-inserted: light-dark(#287a15, #a5ff90);
+  --syntax-deleted: light-dark(#c51f5d, #ff628c);
 
   color-scheme: light dark;
 }
 
-[data-syntax-theme="solarized-light"] pre:has(code) {
+[data-syntax-theme="cobalt2"] pre:has(code) {
   background-color: var(--syntax-background);
   color: var(--syntax-foreground);
 }

--- a/src/themes/dracula.css
+++ b/src/themes/dracula.css
@@ -13,6 +13,8 @@
   --syntax-property: light-dark(#087e8b, #8be9fd);
   --syntax-tag: light-dark(#c21872, #ff79c6);
   --syntax-selector: light-dark(#168a3f, #50fa7b);
+  --syntax-inserted: light-dark(#168a3f, #50fa7b);
+  --syntax-deleted: light-dark(#c21872, #ff79c6);
 
   color-scheme: light dark;
 }
@@ -57,6 +59,6 @@
 
 ::highlight(selector) { color: var(--syntax-selector); }
 
-::highlight(inserted) { color: var(--syntax-function); }
+::highlight(inserted) { color: var(--syntax-inserted); }
 
-::highlight(deleted) { color: var(--syntax-keyword); }
+::highlight(deleted) { color: var(--syntax-deleted); }

--- a/src/themes/github.css
+++ b/src/themes/github.css
@@ -13,6 +13,8 @@
   --syntax-property: light-dark(#0550ae, #79c0ff);
   --syntax-tag: light-dark(#116329, #7ee787);
   --syntax-selector: light-dark(#8250df, #d2a8ff);
+  --syntax-inserted: light-dark(#116329, #7ee787);
+  --syntax-deleted: light-dark(#cf222e, #ff7b72);
 
   color-scheme: light dark;
 }
@@ -80,9 +82,9 @@
 }
 
 ::highlight(inserted) {
-  color: var(--syntax-tag);
+  color: var(--syntax-inserted);
 }
 
 ::highlight(deleted) {
-  color: var(--syntax-keyword);
+  color: var(--syntax-deleted);
 }

--- a/src/themes/index.css
+++ b/src/themes/index.css
@@ -5,3 +5,7 @@
 @import "./monokai.css";
 @import "./night-owl.css";
 @import "./solarized-light.css";
+@import "./vesper.css";
+@import "./min.css";
+@import "./cobalt2.css";
+@import "./tokyo-night.css";

--- a/src/themes/min.css
+++ b/src/themes/min.css
@@ -1,25 +1,25 @@
-/* Reference: Solarized by Ethan Schoonover (MIT) — https://github.com/altercation/solarized/blob/master/textmate-colors-solarized/Solarized%20%28light%29.tmTheme */
-[data-syntax-theme="solarized-light"] {
-  --syntax-background: light-dark(#fdf6e3, #002b36);
-  --syntax-foreground: light-dark(#657b83, #93a1a1);
-  --syntax-comment: light-dark(#93a1a1, #586e75);
-  --syntax-keyword: light-dark(#859900, #b8c927);
-  --syntax-operator: light-dark(#859900, #b8c927);
-  --syntax-string: light-dark(#2aa198, #58c7bd);
-  --syntax-constant: light-dark(#d33682, #e26aa5);
-  --syntax-function: light-dark(#268bd2, #5eb7e5);
-  --syntax-type: light-dark(#b58900, #d9b72f);
-  --syntax-variable: light-dark(#657b83, #93a1a1);
-  --syntax-property: light-dark(#268bd2, #5eb7e5);
-  --syntax-tag: light-dark(#268bd2, #5eb7e5);
-  --syntax-selector: light-dark(#268bd2, #5eb7e5);
-  --syntax-inserted: light-dark(#2aa198, #58c7bd);
-  --syntax-deleted: light-dark(#859900, #b8c927);
+/* Reference: Min Theme by Miguel Solorio (MIT) — https://github.com/miguelsolorio/min-theme/tree/master/themes */
+[data-syntax-theme="min"] {
+  --syntax-background: light-dark(#ffffff, #1f1f1f);
+  --syntax-foreground: light-dark(#24292e, #bbbbbb);
+  --syntax-comment: light-dark(#c2c3c5, #6b737c);
+  --syntax-keyword: light-dark(#d32f2f, #f97583);
+  --syntax-operator: light-dark(#24292e, #b392f0);
+  --syntax-string: light-dark(#22863a, #ffab70);
+  --syntax-constant: light-dark(#1976d2, #f8f8f8);
+  --syntax-function: light-dark(#6f42c1, #b392f0);
+  --syntax-type: light-dark(#6f42c1, #b392f0);
+  --syntax-variable: light-dark(#1976d2, #79b8ff);
+  --syntax-property: light-dark(#1976d2, #79b8ff);
+  --syntax-tag: light-dark(#22863a, #ffab70);
+  --syntax-selector: light-dark(#6f42c1, #b392f0);
+  --syntax-inserted: light-dark(#22863a, #85e89d);
+  --syntax-deleted: light-dark(#d32f2f, #f97583);
 
   color-scheme: light dark;
 }
 
-[data-syntax-theme="solarized-light"] pre:has(code) {
+[data-syntax-theme="min"] pre:has(code) {
   background-color: var(--syntax-background);
   color: var(--syntax-foreground);
 }

--- a/src/themes/monokai.css
+++ b/src/themes/monokai.css
@@ -13,6 +13,8 @@
   --syntax-property: light-dark(#668900, #a6e22e);
   --syntax-tag: light-dark(#c6004f, #f92672);
   --syntax-selector: light-dark(#668900, #a6e22e);
+  --syntax-inserted: light-dark(#8a7b00, #e6db74);
+  --syntax-deleted: light-dark(#c6004f, #f92672);
 
   color-scheme: light dark;
 }
@@ -57,6 +59,6 @@
 
 ::highlight(selector) { color: var(--syntax-selector); }
 
-::highlight(inserted) { color: var(--syntax-string); }
+::highlight(inserted) { color: var(--syntax-inserted); }
 
-::highlight(deleted) { color: var(--syntax-keyword); }
+::highlight(deleted) { color: var(--syntax-deleted); }

--- a/src/themes/night-owl.css
+++ b/src/themes/night-owl.css
@@ -13,6 +13,8 @@
   --syntax-property: light-dark(#4876d6, #82aaff);
   --syntax-tag: light-dark(#0c969b, #7fdbca);
   --syntax-selector: light-dark(#4876d6, #82aaff);
+  --syntax-inserted: light-dark(#c96765, #ecc48d);
+  --syntax-deleted: light-dark(#994cc3, #c792ea);
 
   color-scheme: light dark;
 }
@@ -57,6 +59,6 @@
 
 ::highlight(selector) { color: var(--syntax-selector); }
 
-::highlight(inserted) { color: var(--syntax-string); }
+::highlight(inserted) { color: var(--syntax-inserted); }
 
-::highlight(deleted) { color: var(--syntax-keyword); }
+::highlight(deleted) { color: var(--syntax-deleted); }

--- a/src/themes/tokyo-night.css
+++ b/src/themes/tokyo-night.css
@@ -1,25 +1,25 @@
-/* Reference: Solarized by Ethan Schoonover (MIT) — https://github.com/altercation/solarized/blob/master/textmate-colors-solarized/Solarized%20%28light%29.tmTheme */
-[data-syntax-theme="solarized-light"] {
-  --syntax-background: light-dark(#fdf6e3, #002b36);
-  --syntax-foreground: light-dark(#657b83, #93a1a1);
-  --syntax-comment: light-dark(#93a1a1, #586e75);
-  --syntax-keyword: light-dark(#859900, #b8c927);
-  --syntax-operator: light-dark(#859900, #b8c927);
-  --syntax-string: light-dark(#2aa198, #58c7bd);
-  --syntax-constant: light-dark(#d33682, #e26aa5);
-  --syntax-function: light-dark(#268bd2, #5eb7e5);
-  --syntax-type: light-dark(#b58900, #d9b72f);
-  --syntax-variable: light-dark(#657b83, #93a1a1);
-  --syntax-property: light-dark(#268bd2, #5eb7e5);
-  --syntax-tag: light-dark(#268bd2, #5eb7e5);
-  --syntax-selector: light-dark(#268bd2, #5eb7e5);
-  --syntax-inserted: light-dark(#2aa198, #58c7bd);
-  --syntax-deleted: light-dark(#859900, #b8c927);
+/* Reference: Tokyo Night by Enkia (MIT) — https://github.com/enkia/tokyo-night-vscode-theme/tree/master/themes */
+[data-syntax-theme="tokyo-night"] {
+  --syntax-background: light-dark(#e6e7ed, #1a1b26);
+  --syntax-foreground: light-dark(#343b59, #a9b1d6);
+  --syntax-comment: light-dark(#888b94, #565f89);
+  --syntax-keyword: light-dark(#65359d, #bb9af7);
+  --syntax-operator: light-dark(#006c86, #7dcfff);
+  --syntax-string: light-dark(#385f0d, #9ece6a);
+  --syntax-constant: light-dark(#965027, #ff9e64);
+  --syntax-function: light-dark(#2959aa, #7aa2f7);
+  --syntax-type: light-dark(#65359d, #bb9af7);
+  --syntax-variable: light-dark(#343b58, #c0caf5);
+  --syntax-property: light-dark(#33635c, #73daca);
+  --syntax-tag: light-dark(#8c4351, #f7768e);
+  --syntax-selector: light-dark(#2959aa, #7aa2f7);
+  --syntax-inserted: light-dark(#33635c, #73daca);
+  --syntax-deleted: light-dark(#8c4351, #f7768e);
 
   color-scheme: light dark;
 }
 
-[data-syntax-theme="solarized-light"] pre:has(code) {
+[data-syntax-theme="tokyo-night"] pre:has(code) {
   background-color: var(--syntax-background);
   color: var(--syntax-foreground);
 }

--- a/src/themes/vesper.css
+++ b/src/themes/vesper.css
@@ -1,25 +1,25 @@
-/* Reference: Solarized by Ethan Schoonover (MIT) — https://github.com/altercation/solarized/blob/master/textmate-colors-solarized/Solarized%20%28light%29.tmTheme */
-[data-syntax-theme="solarized-light"] {
-  --syntax-background: light-dark(#fdf6e3, #002b36);
-  --syntax-foreground: light-dark(#657b83, #93a1a1);
-  --syntax-comment: light-dark(#93a1a1, #586e75);
-  --syntax-keyword: light-dark(#859900, #b8c927);
-  --syntax-operator: light-dark(#859900, #b8c927);
-  --syntax-string: light-dark(#2aa198, #58c7bd);
-  --syntax-constant: light-dark(#d33682, #e26aa5);
-  --syntax-function: light-dark(#268bd2, #5eb7e5);
-  --syntax-type: light-dark(#b58900, #d9b72f);
-  --syntax-variable: light-dark(#657b83, #93a1a1);
-  --syntax-property: light-dark(#268bd2, #5eb7e5);
-  --syntax-tag: light-dark(#268bd2, #5eb7e5);
-  --syntax-selector: light-dark(#268bd2, #5eb7e5);
-  --syntax-inserted: light-dark(#2aa198, #58c7bd);
-  --syntax-deleted: light-dark(#859900, #b8c927);
+/* Reference: Vesper by Rauno Freiberg (MIT) — https://github.com/raunofreiberg/vesper/blob/main/themes/Vesper-dark-color-theme.json */
+[data-syntax-theme="vesper"] {
+  --syntax-background: light-dark(#ffffff, #101010);
+  --syntax-foreground: light-dark(#101010, #ffffff);
+  --syntax-comment: light-dark(#707070, #8b8b8b);
+  --syntax-keyword: light-dark(#606060, #a0a0a0);
+  --syntax-operator: light-dark(#606060, #a0a0a0);
+  --syntax-string: light-dark(#007a61, #99ffe4);
+  --syntax-constant: light-dark(#9a5b24, #ffc799);
+  --syntax-function: light-dark(#9a5b24, #ffc799);
+  --syntax-type: light-dark(#9a5b24, #ffc799);
+  --syntax-variable: light-dark(#101010, #ffffff);
+  --syntax-property: light-dark(#101010, #ffffff);
+  --syntax-tag: light-dark(#9a5b24, #ffc799);
+  --syntax-selector: light-dark(#9a5b24, #ffc799);
+  --syntax-inserted: light-dark(#007a61, #99ffe4);
+  --syntax-deleted: light-dark(#b42318, #ff8080);
 
   color-scheme: light dark;
 }
 
-[data-syntax-theme="solarized-light"] pre:has(code) {
+[data-syntax-theme="vesper"] pre:has(code) {
   background-color: var(--syntax-background);
   color: var(--syntax-foreground);
 }

--- a/src/themes/vscode-plus.css
+++ b/src/themes/vscode-plus.css
@@ -13,6 +13,8 @@
   --syntax-property: light-dark(#001080, #9cdcfe);
   --syntax-tag: light-dark(#800000, #569cd6);
   --syntax-selector: light-dark(#800000, #d7ba7d);
+  --syntax-inserted: light-dark(#795e26, #dcdcaa);
+  --syntax-deleted: light-dark(#af00db, #c586c0);
 
   color-scheme: light dark;
 }
@@ -80,9 +82,9 @@
 }
 
 ::highlight(inserted) {
-  color: var(--syntax-function);
+  color: var(--syntax-inserted);
 }
 
 ::highlight(deleted) {
-  color: var(--syntax-keyword);
+  color: var(--syntax-deleted);
 }

--- a/test/highlight.spec.pw.js
+++ b/test/highlight.spec.pw.js
@@ -58,22 +58,38 @@ test.describe("MicroLighter demo site (docs/index.html)", () => {
     expect(diffHighlights.keywords).toEqual([]);
   });
 
-  test("re-highlights after switching themes via the syntax-highlight event", async ({ page }) => {
+  test("loads every bundled theme without changing highlight ranges", async ({ page }) => {
     await page.goto("/", { waitUntil: "networkidle" });
 
     const before = await readHighlights(page);
+    const themes = await page.locator("#theme option").evaluateAll(options =>
+      options.map(option => option.value)
+    );
 
-    await page.evaluate(() => {
-      document.documentElement.dataset.syntaxTheme = "dracula";
-      document.dispatchEvent(new Event("syntax-highlight"));
-    });
-    await page.waitForTimeout(200);
+    for (const theme of themes) {
+      await page.selectOption("#theme", theme);
 
-    const theme = await page.evaluate(() => document.documentElement.dataset.syntaxTheme);
-    const after = await readHighlights(page);
+      const styles = await page.evaluate(() => {
+        const root = getComputedStyle(document.documentElement);
+        const code = getComputedStyle(document.querySelector("pre[lang]"));
+        return {
+          theme: document.documentElement.dataset.syntaxTheme,
+          background: root.getPropertyValue("--syntax-background").trim(),
+          foreground: root.getPropertyValue("--syntax-foreground").trim(),
+          inserted: root.getPropertyValue("--syntax-inserted").trim(),
+          deleted: root.getPropertyValue("--syntax-deleted").trim(),
+          codeBackground: code.backgroundColor
+        };
+      });
 
-    expect(theme).toBe("dracula");
-    expect(after.total).toBe(before.total);
+      expect(styles.theme).toBe(theme);
+      expect(styles.background).not.toBe("");
+      expect(styles.foreground).not.toBe("");
+      expect(styles.inserted).not.toBe("");
+      expect(styles.deleted).not.toBe("");
+      expect(styles.codeBackground).not.toBe("rgba(0, 0, 0, 0)");
+      expect((await readHighlights(page)).total).toBe(before.total);
+    }
   });
 
   test("removes stale ranges when code blocks disappear", async ({ page }) => {


### PR DESCRIPTION
## Summary
- add Vesper, Min, Cobalt2, and Tokyo Night themes
- expose dedicated `--syntax-inserted` and `--syntax-deleted` variables across all bundled themes
- add every theme to the demo and documentation
- verify every bundled theme exposes its required syntax variables

## Testing
- `npm test`