### PR TITLE
Align highlight categories with TextMate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,11 +45,13 @@ the GitHub Pages deployment artifact.
 
 ## How highlighting works
 
-MicroLighter tokenizes code with TextMate grammars, then maps each grammar
-**scope** (e.g. `keyword.control.js`) to a small set of **categories**
-(`keyword`, `string`, `comment`, …) in `src/highlight.js`. Themes then style
-those categories via the `::highlight(category)` pseudo-element. There are no
-per-token `<span>`s — ranges live in the CSS Custom Highlight registry.
+MicroLighter tokenizes code with TextMate grammars, then flattens each grammar
+**scope** (e.g. `keyword.control.js`) to a stable semantic **category**
+(`keyword`, `string`, `comment`, …) in `src/highlight.js`. Category names follow
+canonical TextMate scope terms; related categories share the smaller theme
+palette documented in the README. Themes style categories via the
+`::highlight(category)` pseudo-element. There are no per-token `<span>`s —
+ranges live in the CSS Custom Highlight registry.
 
 ### Adding a grammar
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ and set its name in `data-syntax-theme` on `<body>` or any containing element:
 <link rel="stylesheet" href="./src/themes/night-owl.css">
 ```
 
+Highlight names flatten canonical TextMate scope terms into stable CSS
+identifiers. Related categories share a smaller color palette:
+
+| Theme variable | Highlight categories |
+| --- | --- |
+| `--syntax-comment` | `comment`, `quote` |
+| `--syntax-keyword` | `keyword`, `storage`, `at-rule`, `doctype`, `important`, `section` |
+| `--syntax-operator` | `operator`, `punctuation` |
+| `--syntax-string` | `string`, `regexp`, `attribute-value`, `link`, `raw` |
+| `--syntax-constant` | `numeric`, `boolean`, `constant`, `symbol`, `character-entity`, `entity`, `anchor` |
+| `--syntax-function` | `function`, `decorator`, `animation` |
+| `--syntax-type` | `type`, `support` |
+| `--syntax-variable` | `variable`, `interpolation` |
+| `--syntax-property` | `property`, `key`, `attribute-name` |
+| `--syntax-tag` | `tag` |
+| `--syntax-selector` | `selector` |
+| `--syntax-inserted` | `inserted` |
+| `--syntax-deleted` | `deleted` |
+
 Bundled themes:
 
 - `github`
@@ -171,7 +190,7 @@ token ranges to `Highlight` objects instead of wrapping every token in a
 is a tiny, dependency-free implementation: it parses [TextMate grammars][tm]
 with the browser's native `RegExp` (using the [`d` flag][d-flag] for match
 indices) rather than shipping the Oniguruma WASM engine, lazily loads grammars,
-and maps scopes onto Prism-style category names.
+and flattens scopes into semantic category names derived from TextMate.
 
 Foundations and inspiration:
 
@@ -179,10 +198,9 @@ Foundations and inspiration:
   `patterns`, `repository`, `include`) that MicroLighter interprets. Popularized
   by [TextMate][textmate] and adopted by [VS Code][vscode-grammar], which is
   where most of the community `.tmLanguage.json` grammars come from.
-- **[Prism.js][prism]** — the token category vocabulary (`keyword`, `string`,
-  `punctuation`, `function`, `tag`, etc.) that themes target via
-  `::highlight(...)` mirrors Prism's token class names, so existing Prism themes
-  are easy to port.
+- **[Prism.js][prism]** — inspiration for styling semantic token categories
+  directly with CSS. MicroLighter uses `::highlight(...)` rather than generated
+  token spans and names its categories from TextMate scopes.
 - **[Shiki][shiki]** — the canonical TextMate-grammar-based highlighter for the
   web (backed by VS Code's Oniguruma tokenizer). MicroLighter trades Shiki's
   accuracy and language coverage for zero dependencies and a smaller footprint.

--- a/docs/index.html
+++ b/docs/index.html
@@ -528,7 +528,7 @@
       <article class="feature">
         <span class="feature-index" aria-hidden="true">02</span>
         <div class="feature-specimen size-specimen" aria-hidden="true">
-          <span class="size-value">2.12</span><span class="size-unit">kb<br>gzip</span>
+          <span class="size-value">1.98</span><span class="size-unit">kb<br>gzip</span>
         </div>
         <h2>Blazingly fast!!</h2>
       </article>
@@ -746,7 +746,7 @@ def tokenize(source: str, scopes: list[str]) -> list[Token]:
 
 
 if __name__ == "__main__":
-    for token in tokenize("const x = 42", ["keyword", "number"]):
+    for token in tokenize("const x = 42", ["keyword", "numeric"]):
         print(f"{token.scope}: {token.start}")</code></pre>
     </section>
 
@@ -808,7 +808,9 @@ $tokens: (
   background: #011627,
   foreground: #d6deeb,
   keyword: #c792ea,
-  string: #ecc48d
+  string: #ecc48d,
+  inserted: #addb67,
+  deleted: #ef5350
 );
 
 @mixin syntax-theme($name, $tokens) {

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -21,38 +21,32 @@ export const highlight = (blocks, grammarFor, grammarsByScope) => {
   });
 
   /**
-   * Map a TextMate scope to the smaller set of CSS highlight categories.
+   * Flatten a TextMate scope to a stable semantic CSS highlight category.
    * @param {string} scope
    * @returns {string | undefined}
    */
   const categoryFor = scope => {
-    if (/comment|markup\.quote/.test(scope)) return "comment";
-    if (/markup\.inserted/.test(scope)) return "inserted";
-    if (/markup\.deleted/.test(scope)) return "deleted";
-    if (/constant\.character\.entity/.test(scope)) return "entity";
-    if (/keyword\.control\.doctype/.test(scope)) return "doctype";
-    if (/keyword\.control\.at-rule/.test(scope)) return "atrule";
-    if (/keyword\.other\.important|entity\.name\.section/.test(scope)) return "important";
-    if (/string\.regexp/.test(scope)) return "regex";
-    if (/string\..*attribute-value/.test(scope)) return "attr-value";
-    if (/string\.other\.link|entity\.name\.link/.test(scope)) return "url";
-    if (/string|markup\.raw/.test(scope)) return "string";
-    if (/constant\.numeric|\bnumeric\b/.test(scope)) return "number";
-    if (/constant\.language\.boolean/.test(scope)) return "boolean";
-    if (/constant\.other\.symbol/.test(scope)) return "symbol";
-    if (/constant/.test(scope)) return "constant";
-    if (/keyword\.operator/.test(scope)) return "operator";
-    if (/storage|keyword/.test(scope)) return "keyword";
-    if (/support\.class/.test(scope)) return "builtin";
-    if (/entity\.name\.type\.(?:class|constant)/.test(scope)) return "class-name";
-    if (/entity\.name\.(?:function|decorator|animation)/.test(scope)) return "function";
-    if (/variable|entity\.name\.(?:variable|interpolation)/.test(scope)) return "variable";
-    if (/support\.type\.property-name|entity\.name\.(?:property|key)/.test(scope)) return "property";
-    if (/entity\.name\.tag/.test(scope)) return "tag";
-    if (/entity\.other\.attribute-name/.test(scope)) return "attr-name";
-    if (/entity\.name\.selector/.test(scope)) return "selector";
-    if (/punctuation/.test(scope)) return "punctuation";
-    if (/entity|support/.test(scope)) return "symbol";
+    const parts = scope.split(".");
+    const [first, second, third] = parts;
+    const last = parts.at(-1);
+
+    if (first === "markup" && ["quote", "inserted", "deleted", "raw"].includes(second)) return second;
+    if (first === "entity" && second === "name") return third;
+    if (scope.startsWith("constant.character.entity")) return "character-entity";
+    if (parts.includes("numeric")) return "numeric";
+    if (scope.startsWith("support.type.property-name")) return "property";
+    if (parts.includes("attribute-value")) return "attribute-value";
+    if (scope.startsWith("string.other.link")) return "link";
+
+    if ([
+      "doctype", "at-rule", "important", "regexp", "boolean",
+      "symbol", "operator", "attribute-name"
+    ].includes(last)) return last;
+
+    if ([
+      "comment", "string", "constant", "storage", "keyword",
+      "variable", "punctuation", "entity", "support"
+    ].includes(first)) return first;
   };
 
   /**

--- a/src/themes/dracula.css
+++ b/src/themes/dracula.css
@@ -13,6 +13,8 @@
   --syntax-property: light-dark(#087e8b, #8be9fd);
   --syntax-tag: light-dark(#c21872, #ff79c6);
   --syntax-selector: light-dark(#168a3f, #50fa7b);
+  --syntax-inserted: light-dark(#168a3f, #50fa7b);
+  --syntax-deleted: light-dark(#c21872, #ff79c6);
 
   color-scheme: light dark;
 }
@@ -22,41 +24,51 @@
   color: var(--syntax-foreground);
 }
 
-::highlight(comment) { color: var(--syntax-comment); }
+::highlight(comment),
+::highlight(quote) { color: var(--syntax-comment); }
 
 ::highlight(keyword),
-::highlight(atrule),
+::highlight(storage),
+::highlight(at-rule),
 ::highlight(doctype),
-::highlight(important) { color: var(--syntax-keyword); }
+::highlight(important),
+::highlight(section) { color: var(--syntax-keyword); }
 
 ::highlight(operator),
 ::highlight(punctuation) { color: var(--syntax-operator); }
 
 ::highlight(string),
-::highlight(regex),
-::highlight(attr-value),
-::highlight(url) { color: var(--syntax-string); }
+::highlight(regexp),
+::highlight(attribute-value),
+::highlight(link),
+::highlight(raw) { color: var(--syntax-string); }
 
-::highlight(number),
+::highlight(numeric),
 ::highlight(boolean),
 ::highlight(constant),
 ::highlight(symbol),
+::highlight(character-entity),
+::highlight(anchor),
 ::highlight(entity) { color: var(--syntax-constant); }
 
-::highlight(function) { color: var(--syntax-function); }
+::highlight(function),
+::highlight(decorator),
+::highlight(animation) { color: var(--syntax-function); }
 
-::highlight(class-name),
-::highlight(builtin) { color: var(--syntax-type); }
+::highlight(type),
+::highlight(support) { color: var(--syntax-type); }
 
-::highlight(variable) { color: var(--syntax-variable); }
+::highlight(variable),
+::highlight(interpolation) { color: var(--syntax-variable); }
 
 ::highlight(property),
-::highlight(attr-name) { color: var(--syntax-property); }
+::highlight(key),
+::highlight(attribute-name) { color: var(--syntax-property); }
 
 ::highlight(tag) { color: var(--syntax-tag); }
 
 ::highlight(selector) { color: var(--syntax-selector); }
 
-::highlight(inserted) { color: var(--syntax-function); }
+::highlight(inserted) { color: var(--syntax-inserted); }
 
-::highlight(deleted) { color: var(--syntax-keyword); }
+::highlight(deleted) { color: var(--syntax-deleted); }

--- a/src/themes/github.css
+++ b/src/themes/github.css
@@ -13,6 +13,8 @@
   --syntax-property: light-dark(#0550ae, #79c0ff);
   --syntax-tag: light-dark(#116329, #7ee787);
   --syntax-selector: light-dark(#8250df, #d2a8ff);
+  --syntax-inserted: light-dark(#116329, #7ee787);
+  --syntax-deleted: light-dark(#cf222e, #ff7b72);
 
   color-scheme: light dark;
 }
@@ -22,14 +24,17 @@
   color: var(--syntax-foreground);
 }
 
-::highlight(comment) {
+::highlight(comment),
+::highlight(quote) {
   color: var(--syntax-comment);
 }
 
 ::highlight(keyword),
-::highlight(atrule),
+::highlight(storage),
+::highlight(at-rule),
 ::highlight(doctype),
-::highlight(important) {
+::highlight(important),
+::highlight(section) {
   color: var(--syntax-keyword);
 }
 
@@ -39,35 +44,42 @@
 }
 
 ::highlight(string),
-::highlight(regex),
-::highlight(attr-value),
-::highlight(url) {
+::highlight(regexp),
+::highlight(attribute-value),
+::highlight(link),
+::highlight(raw) {
   color: var(--syntax-string);
 }
 
-::highlight(number),
+::highlight(numeric),
 ::highlight(boolean),
 ::highlight(constant),
 ::highlight(symbol),
+::highlight(character-entity),
+::highlight(anchor),
 ::highlight(entity) {
   color: var(--syntax-constant);
 }
 
-::highlight(function) {
+::highlight(function),
+::highlight(decorator),
+::highlight(animation) {
   color: var(--syntax-function);
 }
 
-::highlight(class-name),
-::highlight(builtin) {
+::highlight(type),
+::highlight(support) {
   color: var(--syntax-type);
 }
 
-::highlight(variable) {
+::highlight(variable),
+::highlight(interpolation) {
   color: var(--syntax-variable);
 }
 
 ::highlight(property),
-::highlight(attr-name) {
+::highlight(key),
+::highlight(attribute-name) {
   color: var(--syntax-property);
 }
 
@@ -80,9 +92,9 @@
 }
 
 ::highlight(inserted) {
-  color: var(--syntax-tag);
+  color: var(--syntax-inserted);
 }
 
 ::highlight(deleted) {
-  color: var(--syntax-keyword);
+  color: var(--syntax-deleted);
 }

--- a/src/themes/monokai.css
+++ b/src/themes/monokai.css
@@ -13,6 +13,8 @@
   --syntax-property: light-dark(#668900, #a6e22e);
   --syntax-tag: light-dark(#c6004f, #f92672);
   --syntax-selector: light-dark(#668900, #a6e22e);
+  --syntax-inserted: light-dark(#8a7b00, #e6db74);
+  --syntax-deleted: light-dark(#c6004f, #f92672);
 
   color-scheme: light dark;
 }
@@ -22,41 +24,51 @@
   color: var(--syntax-foreground);
 }
 
-::highlight(comment) { color: var(--syntax-comment); }
+::highlight(comment),
+::highlight(quote) { color: var(--syntax-comment); }
 
 ::highlight(keyword),
-::highlight(atrule),
+::highlight(storage),
+::highlight(at-rule),
 ::highlight(doctype),
-::highlight(important) { color: var(--syntax-keyword); }
+::highlight(important),
+::highlight(section) { color: var(--syntax-keyword); }
 
 ::highlight(operator),
 ::highlight(punctuation) { color: var(--syntax-operator); }
 
 ::highlight(string),
-::highlight(regex),
-::highlight(attr-value),
-::highlight(url) { color: var(--syntax-string); }
+::highlight(regexp),
+::highlight(attribute-value),
+::highlight(link),
+::highlight(raw) { color: var(--syntax-string); }
 
-::highlight(number),
+::highlight(numeric),
 ::highlight(boolean),
 ::highlight(constant),
 ::highlight(symbol),
+::highlight(character-entity),
+::highlight(anchor),
 ::highlight(entity) { color: var(--syntax-constant); }
 
-::highlight(function) { color: var(--syntax-function); }
+::highlight(function),
+::highlight(decorator),
+::highlight(animation) { color: var(--syntax-function); }
 
-::highlight(class-name),
-::highlight(builtin) { color: var(--syntax-type); }
+::highlight(type),
+::highlight(support) { color: var(--syntax-type); }
 
-::highlight(variable) { color: var(--syntax-variable); }
+::highlight(variable),
+::highlight(interpolation) { color: var(--syntax-variable); }
 
 ::highlight(property),
-::highlight(attr-name) { color: var(--syntax-property); }
+::highlight(key),
+::highlight(attribute-name) { color: var(--syntax-property); }
 
 ::highlight(tag) { color: var(--syntax-tag); }
 
 ::highlight(selector) { color: var(--syntax-selector); }
 
-::highlight(inserted) { color: var(--syntax-string); }
+::highlight(inserted) { color: var(--syntax-inserted); }
 
-::highlight(deleted) { color: var(--syntax-keyword); }
+::highlight(deleted) { color: var(--syntax-deleted); }

--- a/src/themes/night-owl.css
+++ b/src/themes/night-owl.css
@@ -13,6 +13,8 @@
   --syntax-property: light-dark(#4876d6, #82aaff);
   --syntax-tag: light-dark(#0c969b, #7fdbca);
   --syntax-selector: light-dark(#4876d6, #82aaff);
+  --syntax-inserted: light-dark(#c96765, #ecc48d);
+  --syntax-deleted: light-dark(#994cc3, #c792ea);
 
   color-scheme: light dark;
 }
@@ -22,41 +24,51 @@
   color: var(--syntax-foreground);
 }
 
-::highlight(comment) { color: var(--syntax-comment); }
+::highlight(comment),
+::highlight(quote) { color: var(--syntax-comment); }
 
 ::highlight(keyword),
-::highlight(atrule),
+::highlight(storage),
+::highlight(at-rule),
 ::highlight(doctype),
-::highlight(important) { color: var(--syntax-keyword); }
+::highlight(important),
+::highlight(section) { color: var(--syntax-keyword); }
 
 ::highlight(operator),
 ::highlight(punctuation) { color: var(--syntax-operator); }
 
 ::highlight(string),
-::highlight(regex),
-::highlight(attr-value),
-::highlight(url) { color: var(--syntax-string); }
+::highlight(regexp),
+::highlight(attribute-value),
+::highlight(link),
+::highlight(raw) { color: var(--syntax-string); }
 
-::highlight(number),
+::highlight(numeric),
 ::highlight(boolean),
 ::highlight(constant),
 ::highlight(symbol),
+::highlight(character-entity),
+::highlight(anchor),
 ::highlight(entity) { color: var(--syntax-constant); }
 
-::highlight(function) { color: var(--syntax-function); }
+::highlight(function),
+::highlight(decorator),
+::highlight(animation) { color: var(--syntax-function); }
 
-::highlight(class-name),
-::highlight(builtin) { color: var(--syntax-type); }
+::highlight(type),
+::highlight(support) { color: var(--syntax-type); }
 
-::highlight(variable) { color: var(--syntax-variable); }
+::highlight(variable),
+::highlight(interpolation) { color: var(--syntax-variable); }
 
 ::highlight(property),
-::highlight(attr-name) { color: var(--syntax-property); }
+::highlight(key),
+::highlight(attribute-name) { color: var(--syntax-property); }
 
 ::highlight(tag) { color: var(--syntax-tag); }
 
 ::highlight(selector) { color: var(--syntax-selector); }
 
-::highlight(inserted) { color: var(--syntax-string); }
+::highlight(inserted) { color: var(--syntax-inserted); }
 
-::highlight(deleted) { color: var(--syntax-keyword); }
+::highlight(deleted) { color: var(--syntax-deleted); }

--- a/src/themes/solarized-light.css
+++ b/src/themes/solarized-light.css
@@ -13,6 +13,8 @@
   --syntax-property: light-dark(#268bd2, #5eb7e5);
   --syntax-tag: light-dark(#268bd2, #5eb7e5);
   --syntax-selector: light-dark(#268bd2, #5eb7e5);
+  --syntax-inserted: light-dark(#2aa198, #58c7bd);
+  --syntax-deleted: light-dark(#859900, #b8c927);
 
   color-scheme: light dark;
 }
@@ -22,41 +24,51 @@
   color: var(--syntax-foreground);
 }
 
-::highlight(comment) { color: var(--syntax-comment); }
+::highlight(comment),
+::highlight(quote) { color: var(--syntax-comment); }
 
 ::highlight(keyword),
-::highlight(atrule),
+::highlight(storage),
+::highlight(at-rule),
 ::highlight(doctype),
-::highlight(important) { color: var(--syntax-keyword); }
+::highlight(important),
+::highlight(section) { color: var(--syntax-keyword); }
 
 ::highlight(operator),
 ::highlight(punctuation) { color: var(--syntax-operator); }
 
 ::highlight(string),
-::highlight(regex),
-::highlight(attr-value),
-::highlight(url) { color: var(--syntax-string); }
+::highlight(regexp),
+::highlight(attribute-value),
+::highlight(link),
+::highlight(raw) { color: var(--syntax-string); }
 
-::highlight(number),
+::highlight(numeric),
 ::highlight(boolean),
 ::highlight(constant),
 ::highlight(symbol),
+::highlight(character-entity),
+::highlight(anchor),
 ::highlight(entity) { color: var(--syntax-constant); }
 
-::highlight(function) { color: var(--syntax-function); }
+::highlight(function),
+::highlight(decorator),
+::highlight(animation) { color: var(--syntax-function); }
 
-::highlight(class-name),
-::highlight(builtin) { color: var(--syntax-type); }
+::highlight(type),
+::highlight(support) { color: var(--syntax-type); }
 
-::highlight(variable) { color: var(--syntax-variable); }
+::highlight(variable),
+::highlight(interpolation) { color: var(--syntax-variable); }
 
 ::highlight(property),
-::highlight(attr-name) { color: var(--syntax-property); }
+::highlight(key),
+::highlight(attribute-name) { color: var(--syntax-property); }
 
 ::highlight(tag) { color: var(--syntax-tag); }
 
 ::highlight(selector) { color: var(--syntax-selector); }
 
-::highlight(inserted) { color: var(--syntax-string); }
+::highlight(inserted) { color: var(--syntax-inserted); }
 
-::highlight(deleted) { color: var(--syntax-keyword); }
+::highlight(deleted) { color: var(--syntax-deleted); }

--- a/src/themes/vscode-plus.css
+++ b/src/themes/vscode-plus.css
@@ -13,6 +13,8 @@
   --syntax-property: light-dark(#001080, #9cdcfe);
   --syntax-tag: light-dark(#800000, #569cd6);
   --syntax-selector: light-dark(#800000, #d7ba7d);
+  --syntax-inserted: light-dark(#795e26, #dcdcaa);
+  --syntax-deleted: light-dark(#af00db, #c586c0);
 
   color-scheme: light dark;
 }
@@ -22,14 +24,17 @@
   color: var(--syntax-foreground);
 }
 
-::highlight(comment) {
+::highlight(comment),
+::highlight(quote) {
   color: var(--syntax-comment);
 }
 
 ::highlight(keyword),
-::highlight(atrule),
+::highlight(storage),
+::highlight(at-rule),
 ::highlight(doctype),
-::highlight(important) {
+::highlight(important),
+::highlight(section) {
   color: var(--syntax-keyword);
 }
 
@@ -39,35 +44,42 @@
 }
 
 ::highlight(string),
-::highlight(regex),
-::highlight(attr-value),
-::highlight(url) {
+::highlight(regexp),
+::highlight(attribute-value),
+::highlight(link),
+::highlight(raw) {
   color: var(--syntax-string);
 }
 
-::highlight(number),
+::highlight(numeric),
 ::highlight(boolean),
 ::highlight(constant),
 ::highlight(symbol),
+::highlight(character-entity),
+::highlight(anchor),
 ::highlight(entity) {
   color: var(--syntax-constant);
 }
 
-::highlight(function) {
+::highlight(function),
+::highlight(decorator),
+::highlight(animation) {
   color: var(--syntax-function);
 }
 
-::highlight(class-name),
-::highlight(builtin) {
+::highlight(type),
+::highlight(support) {
   color: var(--syntax-type);
 }
 
-::highlight(variable) {
+::highlight(variable),
+::highlight(interpolation) {
   color: var(--syntax-variable);
 }
 
 ::highlight(property),
-::highlight(attr-name) {
+::highlight(key),
+::highlight(attribute-name) {
   color: var(--syntax-property);
 }
 
@@ -80,9 +92,9 @@
 }
 
 ::highlight(inserted) {
-  color: var(--syntax-function);
+  color: var(--syntax-inserted);
 }
 
 ::highlight(deleted) {
-  color: var(--syntax-keyword);
+  color: var(--syntax-deleted);
 }

--- a/test/highlight.spec.pw.js
+++ b/test/highlight.spec.pw.js
@@ -30,9 +30,116 @@ test.describe("MicroLighter demo site (docs/index.html)", () => {
 
     const { categories } = await readHighlights(page);
 
-    for (const category of ["keyword", "string", "comment", "function", "number"]) {
+    for (const category of ["keyword", "string", "comment", "function", "numeric"]) {
       expect(categories).toContain(category);
     }
+  });
+
+  test("maps TextMate scopes to stable semantic categories", async ({ page }) => {
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    const actual = await page.evaluate(async () => {
+      const { highlight } = await import("/microlighter/highlight.js");
+      const mappings = [
+        ["comment.block.html", "comment"],
+        ["markup.quote", "quote"],
+        ["markup.inserted.diff", "inserted"],
+        ["markup.deleted.diff", "deleted"],
+        ["constant.character.entity", "character-entity"],
+        ["keyword.control.doctype", "doctype"],
+        ["keyword.control.at-rule", "at-rule"],
+        ["keyword.other.important", "important"],
+        ["entity.name.section", "section"],
+        ["string.regexp", "regexp"],
+        ["string.quoted.attribute-value", "attribute-value"],
+        ["string.other.link", "link"],
+        ["markup.raw", "raw"],
+        ["string.unquoted.fenced-code", "string"],
+        ["constant.numeric.line-number.diff", "numeric"],
+        ["constant.language.boolean", "boolean"],
+        ["constant.other.symbol", "symbol"],
+        ["constant.language", "constant"],
+        ["keyword.operator", "operator"],
+        ["storage.type", "storage"],
+        ["keyword.control.ts", "keyword"],
+        ["support.class.builtin", "support"],
+        ["entity.name.type.class", "type"],
+        ["entity.name.function.macro", "function"],
+        ["entity.name.decorator", "decorator"],
+        ["entity.name.animation", "animation"],
+        ["entity.name.variable.assignment", "variable"],
+        ["entity.name.interpolation", "interpolation"],
+        ["support.type.property-name", "property"],
+        ["entity.name.key", "key"],
+        ["entity.name.tag", "tag"],
+        ["entity.other.attribute-name", "attribute-name"],
+        ["entity.name.selector", "selector"],
+        ["punctuation.definition.string.begin", "punctuation"],
+        ["entity.name.anchor", "anchor"]
+      ];
+      const tokens = mappings.map((_, index) => `@${index}`);
+      const code = document.createElement("code");
+      code.textContent = tokens.join(" ");
+      document.body.append(code);
+
+      for (const category of CSS.highlights.keys()) CSS.highlights.delete(category);
+
+      const grammar = {
+        scopeName: "source.test",
+        patterns: mappings.map(([scope], index) => ({
+          match: `${tokens[index]}\\b`,
+          name: scope
+        }))
+      };
+      highlight([code], () => grammar, new Map());
+
+      return Object.fromEntries(
+        [...CSS.highlights].map(([category, ranges]) => [
+          category,
+          [...ranges].map(range => range.toString())
+        ])
+      );
+    });
+
+    const expected = {
+      comment: ["@0"],
+      quote: ["@1"],
+      inserted: ["@2"],
+      deleted: ["@3"],
+      "character-entity": ["@4"],
+      doctype: ["@5"],
+      "at-rule": ["@6"],
+      important: ["@7"],
+      section: ["@8"],
+      regexp: ["@9"],
+      "attribute-value": ["@10"],
+      link: ["@11"],
+      raw: ["@12"],
+      string: ["@13"],
+      numeric: ["@14"],
+      boolean: ["@15"],
+      symbol: ["@16"],
+      constant: ["@17"],
+      operator: ["@18"],
+      storage: ["@19"],
+      keyword: ["@20"],
+      support: ["@21"],
+      type: ["@22"],
+      function: ["@23"],
+      decorator: ["@24"],
+      animation: ["@25"],
+      variable: ["@26"],
+      interpolation: ["@27"],
+      property: ["@28"],
+      key: ["@29"],
+      tag: ["@30"],
+      "attribute-name": ["@31"],
+      selector: ["@32"],
+      punctuation: ["@33"],
+      anchor: ["@34"]
+    };
+
+    expect(actual).toEqual(expected);
   });
 
   test("highlights inserted and deleted git diff lines", async ({ page }) => {


### PR DESCRIPTION
## Summary
- align CSS Highlight category names with canonical TextMate terminology
- simplify scope resolution using TextMate segment structure
- add dedicated inserted/deleted theme variables and exhaustive mapping coverage
- document the category-to-palette interface

## Size
- bundle: 2.12 KiB gzip -> 1.98 KiB gzip