### PR TITLE
Add lazy frontend language support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ ranges live in the CSS Custom Highlight registry.
 1. Add `src/grammars/<language>.js` exporting a TextMate grammar as the default
    export (it must include a `scopeName`).
 2. If the language is commonly referenced by an alias (e.g. `ts`, `yml`), add it
-   to the `aliases` map in `src/grammar-dependencies.js`.
+   to the `aliases` map in `src/language-aliases.js`.
 3. Add a code block for it to `docs/index.html` so it's covered by the demo and
    the tests.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,30 @@ its parent `<pre>`. The older `<pre lang="javascript">` form remains supported
 for compatibility but is deprecated because HTML's `lang` attribute describes
 human language.
 
+Common aliases work automatically in both the import API and auto-run bundles.
+The same map is exported as a **get out of jail free card** when composing
+project-specific aliases:
+
+```js
+import languageAliases from "microlighter/language-aliases";
+
+console.log(languageAliases.jsx); // "javascript"
+```
+
+The map can be extended with project-specific names:
+
+```js
+await highlightAll({
+  languageAliases: {
+    ...languageAliases,
+    ecmascript: "javascript",
+    shellsession: "bash"
+  }
+});
+```
+
+Alias targets must be names of shipped grammars.
+
 ### 1. Auto (drop-in)
 
 The auto-run entry (`microlighter/microlighter.js`, or the minified
@@ -121,15 +145,14 @@ Grammars ship as ES modules in `src/grammars/` and are loaded on demand:
 `assembly`, `bash`, `c`, `cpp`, `csharp`, `css`, `dart`, `dockerfile`, `git-diff`,
 `go`, `graphql`, `html`, `java`, `javascript`, `json`, `kotlin`, `lua`, `markdown`,
 `objective-c`, `perl`, `php`, `powershell`, `python`, `r`, `ruby`, `rust`, `scss`,
-`sql`, `swift`, `toml`, `tsx`, `typescript`, `yaml`. `tsx` is a genuine grammar
-(TypeScript constructs plus JSX), not just an alias to `typescript`. `objective-c`
-reuses the shared `c` grammar's comments, preprocessor, and strings via external
-includes. `assembly` targets generic x86 Intel/NASM syntax. Common aliases (`js`,
-`jsx`, `ts`, `sh`, `shell`, `zsh`, `yml`, `rb`, `md`, `diff`, `patch`, `sass`, `py`,
-`rs`, `c++`, `cc`, `cxx`, `h`, `hpp`, `cs`, `kt`, `kts`, `ps1`, `pwsh`, `gql`,
-`docker`, `xml`, `svg`, `webmanifest`, `objc`, `objectivec`, `obj-c`, `asm`,
-`nasm`, `x86asm`, `pl`, …) resolve automatically — `xml` and `svg` reuse the
-HTML grammar and `webmanifest` reuses JSON.
+`sql`, `svelte`, `swift`, `toml`, `tsx`, `typescript`, `vue`, `yaml`. `tsx` is a
+genuine grammar (TypeScript constructs plus JSX), not just an alias to
+`typescript`. `objective-c` reuses the shared `c` grammar's comments,
+preprocessor, and strings via external includes. `assembly` targets generic x86
+Intel/NASM syntax. First-party common blog-oriented aliases include:
+`js` and `jsx` → `javascript`, `ts` → `typescript`, `sass` → `scss`, `sh` and
+`shell` and `zsh` → `bash`, `yml` → `yaml`, `md` → `markdown`, `docker` →
+`dockerfile`, `py` → `python`, `rb` → `ruby`, and `gql` → `graphql`.
 
 ## Build
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -600,7 +600,7 @@
       <article class="feature">
         <span class="feature-index" aria-hidden="true">02</span>
         <div class="feature-specimen size-specimen" aria-hidden="true">
-          <span class="size-value">2.18</span><span class="size-unit">kb<br>gzip</span>
+          <span class="size-value">2.03</span><span class="size-unit">kb<br>gzip</span>
         </div>
         <h2>Blazingly fast!!</h2>
       </article>
@@ -825,6 +825,8 @@ export function YetAnotherTodoApp(): JSX.Element {
             <li data-lang="javascript">JavaScript</li>
             <li data-lang="typescript">TypeScript</li>
             <li data-lang="tsx">TSX</li>
+            <li data-lang="svelte">Svelte</li>
+            <li data-lang="vue">Vue</li>
           </ul>
         </div>
         <div class="language-group">
@@ -1071,6 +1073,13 @@ SELECT id, scope FROM tokens
 WHERE start &gt;= 0
 LIMIT 10;</code></pre>
       </template>
+      <template data-lang="svelte" data-label="Svelte">
+        <pre><code class="language-svelte">&lt;script&gt;
+  let count = 0;
+&lt;/script&gt;
+
+&lt;button on:click={() =&gt; count++}&gt;Count: {count}&lt;/button&gt;</code></pre>
+      </template>
       <template data-lang="swift" data-label="Swift">
         <pre><code class="language-swift">struct Token {
     let scope: String
@@ -1096,6 +1105,13 @@ rollup = "4.46.2"</code></pre>
 }
 
 const answer: number = 42;</code></pre>
+      </template>
+      <template data-lang="vue" data-label="Vue">
+        <pre><code class="language-vue">&lt;script setup&gt;
+const count = ref(0)
+&lt;/script&gt;
+
+&lt;button @click="count++"&gt;Count: {{ count }}&lt;/button&gt;</code></pre>
       </template>
       <template data-lang="yaml" data-label="YAML">
         <pre><code class="language-yaml">name: CI

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "./dist/index.js",
   "exports": {
     ".": "./dist/index.js",
+    "./language-aliases": "./dist/language-aliases.js",
     "./*": "./dist/*"
   },
   "files": [
@@ -17,7 +18,7 @@
     "./dist/microlighter.min.js"
   ],
   "sizeLimit": {
-    "dist/microlighter.min.js": 3000
+    "dist/microlighter.min.js": 2090
   },
   "scripts": {
     "build": "./build.sh",

--- a/src/grammar-dependencies.js
+++ b/src/grammar-dependencies.js
@@ -1,50 +1,10 @@
-const aliases = {
-  asm: "assembly",
-  "c++": "cpp",
-  cc: "cpp",
-  cs: "csharp",
-  cxx: "cpp",
-  diff: "git-diff",
-  docker: "dockerfile",
-  golang: "go",
-  gql: "graphql",
-  h: "c",
-  hpp: "cpp",
-  htm: "html",
-  js: "javascript",
-  jsx: "javascript",
-  kt: "kotlin",
-  kts: "kotlin",
-  md: "markdown",
-  nasm: "assembly",
-  "obj-c": "objective-c",
-  objc: "objective-c",
-  objectivec: "objective-c",
-  patch: "git-diff",
-  pl: "perl",
-  ps1: "powershell",
-  pwsh: "powershell",
-  py: "python",
-  rb: "ruby",
-  rs: "rust",
-  sass: "scss",
-  sh: "bash",
-  shell: "bash",
-  svg: "html",
-  ts: "typescript",
-  webmanifest: "json",
-  x86asm: "assembly",
-  xml: "html",
-  yml: "yaml",
-  zsh: "bash"
-};
-
 /**
  * Convert a supported language alias to its grammar module name.
  * @param {string} language
+ * @param {Object<string, string>} aliases
  * @returns {string}
  */
-export const normalizeLanguage = language => aliases[language] || language;
+export const normalizeLanguage = (language, aliases) => aliases[language] || language;
 
 /**
  * Find grammar modules referenced by external TextMate scope includes.
@@ -62,7 +22,7 @@ export const externalLanguagesFor = value => {
       if (typeof item.include === "string" && !/^[#$]/.test(item.include)) {
         const scope = item.include.split("#")[0];
         const match = scope.match(/^(?:source|text)\.([a-z0-9_-]+)/);
-        if (match) languages.add(normalizeLanguage(match[1]));
+        if (match) languages.add(match[1]);
       }
       Object.values(item).forEach(visit);
     }
@@ -77,11 +37,9 @@ export const externalLanguagesFor = value => {
  * @param {string} language
  * @returns {Promise<Object | null>}
  */
-const importGrammar = language => {
-  return import(`./grammars/${language}.js`)
-    .then(module => module.default)
-    .catch(() => null);
-};
+const grammarFor = language => import(`./grammars/${language}.js`)
+  .then(module => module.default)
+  .catch(() => null);
 
 /**
  * Create a cached loader that also resolves external grammar dependencies.
@@ -91,13 +49,22 @@ const importGrammar = language => {
  *   byScope: Map<string, Object>
  * }>}
  */
-export const createGrammarLoader = (importLanguage = importGrammar) => {
+export const createGrammarLoader = (importLanguage = grammarFor) => {
   const grammarModules = new Map();
   const grammars = {
     byLanguage: {},
     byScope: new Map()
   };
+  let aliasesModule;
 
+  const normalizeLanguages = async languages => {
+    aliasesModule ||= import(`./${"language-aliases"}.js`);
+    const { default: aliases } = await aliasesModule;
+    return [...new Set(languages)].map(requested => ({
+      requested,
+      canonical: normalizeLanguage(requested, aliases)
+    })).filter(({ canonical }) => /^[a-z0-9_-]+$/.test(canonical));
+  };
   /**
    * Import and index a grammar once for the lifetime of this loader.
    * @param {string} language
@@ -119,15 +86,23 @@ export const createGrammarLoader = (importLanguage = importGrammar) => {
   };
 
   return async languages => {
-    let pendingLanguages = [...new Set(languages)]
+    const requestedLanguages = await normalizeLanguages(languages);
+    let pendingLanguages = requestedLanguages
+      .map(({ canonical }) => canonical)
       .filter(language => !grammarModules.has(language));
 
     while (pendingLanguages.length) {
       const loadedGrammars = (await Promise.all(pendingLanguages.map(loadGrammar))).filter(Boolean);
-      pendingLanguages = [...new Set(loadedGrammars
-        .flatMap(grammar => [...externalLanguagesFor(grammar)]))]
-        .filter(language => !grammarModules.has(language));
+      pendingLanguages = [...new Set(loadedGrammars.flatMap(grammar =>
+        grammar.dependencies || [...externalLanguagesFor(grammar)]
+      ))].filter(language => !grammarModules.has(language));
     }
+
+    requestedLanguages.forEach(({ requested, canonical }) => {
+      if (grammars.byLanguage[canonical]) {
+        grammars.byLanguage[requested] = grammars.byLanguage[canonical];
+      }
+    });
 
     return grammars;
   };

--- a/src/grammars/cpp.js
+++ b/src/grammars/cpp.js
@@ -1,6 +1,7 @@
 // Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/cpp/syntaxes/cpp.tmLanguage.json
 export default {
   scopeName: "source.cpp",
+  dependencies: ["c"],
   patterns: [
     { include: "source.c#comments" },
     { include: "source.c#preprocessor" },

--- a/src/grammars/html.js
+++ b/src/grammars/html.js
@@ -1,6 +1,7 @@
 // Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/html/syntaxes/html.tmLanguage.json
 export default {
   scopeName: "text.html.basic",
+  dependencies: ["css", "json", "javascript"],
   patterns: [
     { include: "#comments" },
     { include: "#doctype" },

--- a/src/grammars/markdown.js
+++ b/src/grammars/markdown.js
@@ -1,6 +1,7 @@
 // Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json
 export default {
   scopeName: "text.html.markdown",
+  dependencies: ["yaml"],
   patterns: [
     { include: "#front-matter" },
     { include: "#comments" },

--- a/src/grammars/objective-c.js
+++ b/src/grammars/objective-c.js
@@ -1,6 +1,7 @@
 // Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/objective-c/syntaxes/objective-c.tmLanguage.json
 export default {
   scopeName: "source.objc",
+  dependencies: ["c"],
   patterns: [
     { include: "source.c#comments" },
     { include: "source.c#preprocessor" },

--- a/src/grammars/scss.js
+++ b/src/grammars/scss.js
@@ -1,6 +1,7 @@
 // Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/scss/syntaxes/scss.tmLanguage.json
 export default {
   scopeName: "source.scss",
+  dependencies: ["css"],
   patterns: [
     { match: "//.*$", name: "comment.line.double-slash" },
     { match: "\\$[a-zA-Z_-][\\w-]*", name: "entity.name.variable" },

--- a/src/grammars/svelte.js
+++ b/src/grammars/svelte.js
@@ -1,0 +1,89 @@
+// Reference: Svelte Language Tools (MIT) — https://github.com/sveltejs/language-tools/blob/master/packages/svelte-vscode/syntaxes/svelte.tmLanguage.src.yaml
+export default {
+  scopeName: "source.svelte",
+  dependencies: ["html", "css", "scss", "javascript", "typescript"],
+  patterns: [
+    { include: "#comments" },
+    { include: "#typescript" },
+    { include: "#javascript" },
+    { include: "#scss" },
+    { include: "#css" },
+    { include: "#blocks" },
+    { include: "#interpolation" },
+    { include: "#tags" },
+    { include: "text.html.basic" }
+  ],
+  repository: {
+    comments: { begin: "<!--", end: "-->", name: "comment.block" },
+    typescript: {
+      begin: "<(script)\\b(?=[^>]*\\blang\\s*=\\s*(['\"])(?:ts|typescript)\\2)[^>]*>",
+      end: "</(script)\\s*>",
+      beginCaptures: { 1: { name: "entity.name.tag" } },
+      endCaptures: { 1: { name: "entity.name.tag" } },
+      contentName: "source.ts.embedded.svelte",
+      patterns: [{ include: "source.ts" }]
+    },
+    javascript: {
+      begin: "<(script)\\b[^>]*>",
+      end: "</(script)\\s*>",
+      beginCaptures: { 1: { name: "entity.name.tag" } },
+      endCaptures: { 1: { name: "entity.name.tag" } },
+      contentName: "source.js.embedded.svelte",
+      patterns: [{ include: "source.js" }]
+    },
+    scss: {
+      begin: "<(style)\\b(?=[^>]*\\blang\\s*=\\s*(['\"])scss\\2)[^>]*>",
+      end: "</(style)\\s*>",
+      beginCaptures: { 1: { name: "entity.name.tag" } },
+      endCaptures: { 1: { name: "entity.name.tag" } },
+      contentName: "source.css.scss.embedded.svelte",
+      patterns: [{ include: "source.scss" }]
+    },
+    css: {
+      begin: "<(style)\\b[^>]*>",
+      end: "</(style)\\s*>",
+      beginCaptures: { 1: { name: "entity.name.tag" } },
+      endCaptures: { 1: { name: "entity.name.tag" } },
+      contentName: "source.css.embedded.svelte",
+      patterns: [{ include: "source.css" }]
+    },
+    blocks: {
+      match: "\\{([#/:@])\\s*(if|else|each|key|await|then|catch|snippet|render|html|debug|const)\\b",
+      captures: {
+        1: { name: "punctuation.definition.keyword" },
+        2: { name: "keyword.control" }
+      }
+    },
+    interpolation: {
+      begin: "\\{(?![#/:@])",
+      end: "\\}",
+      beginCaptures: { 0: { name: "punctuation.section.embedded.begin" } },
+      endCaptures: { 0: { name: "punctuation.section.embedded.end" } },
+      contentName: "source.js.embedded.svelte",
+      patterns: [{ include: "source.js" }]
+    },
+    tags: {
+      begin: "<(/?)([a-zA-Z][\\w.:-]*)",
+      end: ">",
+      beginCaptures: { 2: { name: "entity.name.tag" } },
+      patterns: [
+        { include: "#directive" },
+        { include: "#shorthand" },
+        { include: "text.html.basic#inline-css" },
+        { include: "text.html.basic#attributes" },
+        { include: "text.html.basic#unquoted-attributes" },
+        { include: "text.html.basic#boolean-attributes" }
+      ]
+    },
+    directive: {
+      match: "[ \\t]+((?:bind|on|class|use|transition|in|out|animate|let):[\\w-]+(?:\\|[\\w-]+)*)",
+      captures: { 1: { name: "entity.other.attribute-name" } }
+    },
+    shorthand: {
+      begin: "[ \\t]+\\{",
+      end: "\\}",
+      contentName: "source.js.embedded.svelte",
+      patterns: [{ include: "source.js" }]
+    }
+  }
+};

--- a/src/grammars/tsx.js
+++ b/src/grammars/tsx.js
@@ -4,6 +4,7 @@
 // TypeScript.tmLanguage.json and TypeScriptReact.tmLanguage.json relate upstream.
 export default {
   scopeName: "source.tsx",
+  dependencies: ["javascript", "typescript"],
   patterns: [
     { include: "source.js#comments" },
     { include: "source.js#strings" },

--- a/src/grammars/typescript.js
+++ b/src/grammars/typescript.js
@@ -1,6 +1,7 @@
 // Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/typescript-basics/syntaxes/TypeScript.tmLanguage.json
 export default {
   scopeName: "source.ts",
+  dependencies: ["javascript"],
   patterns: [
     { include: "source.js#comments" },
     { include: "source.js#strings" },

--- a/src/grammars/vue.js
+++ b/src/grammars/vue.js
@@ -1,0 +1,86 @@
+// Reference: Vue Language Tools (MIT) — https://github.com/vuejs/language-tools/blob/master/extensions/vscode/syntaxes/vue.tmLanguage.json
+export default {
+  scopeName: "text.html.vue",
+  dependencies: ["html", "css", "scss", "javascript", "typescript"],
+  patterns: [
+    { include: "#comments" },
+    { include: "#typescript" },
+    { include: "#javascript" },
+    { include: "#scss" },
+    { include: "#css" },
+    { include: "#interpolation" },
+    { include: "#tags" },
+    { include: "text.html.basic" }
+  ],
+  repository: {
+    comments: { begin: "<!--", end: "-->", name: "comment.block" },
+    typescript: {
+      begin: "<(script)\\b(?=[^>]*\\blang\\s*=\\s*(['\"])(?:ts|typescript)\\2)[^>]*>",
+      end: "</(script)\\s*>",
+      beginCaptures: { 1: { name: "entity.name.tag" } },
+      endCaptures: { 1: { name: "entity.name.tag" } },
+      contentName: "source.ts.embedded.vue",
+      patterns: [{ include: "source.ts" }]
+    },
+    javascript: {
+      begin: "<(script)\\b[^>]*>",
+      end: "</(script)\\s*>",
+      beginCaptures: { 1: { name: "entity.name.tag" } },
+      endCaptures: { 1: { name: "entity.name.tag" } },
+      contentName: "source.js.embedded.vue",
+      patterns: [{ include: "source.js" }]
+    },
+    scss: {
+      begin: "<(style)\\b(?=[^>]*\\blang\\s*=\\s*(['\"])scss\\2)[^>]*>",
+      end: "</(style)\\s*>",
+      beginCaptures: { 1: { name: "entity.name.tag" } },
+      endCaptures: { 1: { name: "entity.name.tag" } },
+      contentName: "source.css.scss.embedded.vue",
+      patterns: [{ include: "source.scss" }]
+    },
+    css: {
+      begin: "<(style)\\b[^>]*>",
+      end: "</(style)\\s*>",
+      beginCaptures: { 1: { name: "entity.name.tag" } },
+      endCaptures: { 1: { name: "entity.name.tag" } },
+      contentName: "source.css.embedded.vue",
+      patterns: [{ include: "source.css" }]
+    },
+    interpolation: {
+      begin: "\\{\\{",
+      end: "\\}\\}",
+      beginCaptures: { 0: { name: "punctuation.section.embedded.begin" } },
+      endCaptures: { 0: { name: "punctuation.section.embedded.end" } },
+      contentName: "source.js.embedded.vue",
+      patterns: [{ include: "source.js" }]
+    },
+    tags: {
+      begin: "<(/?)([a-zA-Z][\\w.:-]*)",
+      end: ">",
+      beginCaptures: { 2: { name: "entity.name.tag" } },
+      patterns: [
+        { include: "#directive-value" },
+        { include: "#directive" },
+        { include: "text.html.basic#inline-css" },
+        { include: "text.html.basic#attributes" },
+        { include: "text.html.basic#unquoted-attributes" },
+        { include: "text.html.basic#boolean-attributes" }
+      ]
+    },
+    "directive-value": {
+      begin: "[ \\t]+((?:v-[\\w-]+(?::[\\w-]+)?|[:@#][\\w-]+)(?:\\.[\\w-]+)*)\\s*=\\s*(['\"])",
+      end: "\\2",
+      beginCaptures: {
+        1: { name: "entity.other.attribute-name" },
+        2: { name: "punctuation.definition.string.begin" }
+      },
+      endCaptures: { 0: { name: "punctuation.definition.string.end" } },
+      contentName: "source.js.embedded.vue",
+      patterns: [{ include: "source.js" }]
+    },
+    directive: {
+      match: "[ \\t]+((?:v-[\\w-]+(?::[\\w-]+)?|[:@#][\\w-]+)(?:\\.[\\w-]+)*)",
+      captures: { 1: { name: "entity.other.attribute-name" } }
+    }
+  }
+};

--- a/src/highlight-all.js
+++ b/src/highlight-all.js
@@ -1,0 +1,30 @@
+import { highlight } from "./highlight.js";
+import { createGrammarLoader } from "./grammar-dependencies.js";
+
+const languageClassFor = element => [...element.classList]
+  .find(className => className.startsWith("language-"))
+  ?.slice("language-".length);
+
+export const languageFor = code => {
+  const pre = code.parentElement;
+  const language = languageClassFor(code)
+    || code.dataset.language
+    || languageClassFor(pre)
+    || pre.dataset.language
+    // Deprecated: `lang` describes human language, not programming language.
+    || pre.getAttribute("lang")
+    || "";
+
+  return language.toLowerCase();
+};
+export const loadGrammars = createGrammarLoader();
+
+export const highlightAll = async ({ root = document, selector = "pre > code" } = {}) => {
+  const codeBlocks = [...root.querySelectorAll(selector)].filter(languageFor);
+  const languages = [...new Set(codeBlocks.map(languageFor))]
+    .filter(language => /^[a-z0-9_-]+$/.test(language));
+  const grammars = await loadGrammars(languages);
+
+  highlight(codeBlocks, code => grammars.byLanguage[languageFor(code)], grammars.byScope);
+  return codeBlocks;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,28 +1,5 @@
 import { highlight } from "./highlight.js";
-import { createGrammarLoader, normalizeLanguage } from "./grammar-dependencies.js";
-
-const languageClassFor = element => [...element.classList]
-  .find(className => className.startsWith("language-"))
-  ?.slice("language-".length);
-
-/**
- * Read and normalize the language declared by a code block.
- * @param {HTMLElement} code
- * @returns {string}
- */
-const languageFor = code => {
-  const pre = code.parentElement;
-  const language = languageClassFor(code)
-    || code.dataset.language
-    || languageClassFor(pre)
-    || pre.dataset.language
-    // Deprecated: `lang` describes human language, not programming language.
-    || pre.getAttribute("lang")
-    || "";
-
-  return normalizeLanguage(language.toLowerCase());
-};
-const loadGrammars = createGrammarLoader();
+import { languageFor, loadGrammars } from "./highlight-all.js";
 
 /**
  * Scan the DOM for code blocks, lazily load the grammars they need, and
@@ -31,14 +8,24 @@ const loadGrammars = createGrammarLoader();
  * @param {Object} [options]
  * @param {ParentNode} [options.root=document] Root to query within.
  * @param {string} [options.selector] Code block selector.
+ * @param {Object<string, string>} [options.languageAliases] Custom aliases
+ * mapping code block language names to shipped grammar names.
  * @returns {Promise<HTMLElement[]>} The highlighted code elements.
  */
-export const highlightAll = async ({ root = document, selector = "pre > code" } = {}) => {
-  const codeBlocks = [...root.querySelectorAll(selector)].filter(languageFor);
-  const languages = [...new Set(codeBlocks.map(languageFor))]
+export const highlightAll = async ({
+  root = document,
+  selector = "pre > code",
+  languageAliases
+} = {}) => {
+  const language = code => {
+    const requested = languageFor(code);
+    return languageAliases?.[requested] || requested;
+  };
+  const codeBlocks = [...root.querySelectorAll(selector)].filter(language);
+  const languages = [...new Set(codeBlocks.map(language))]
     .filter(language => /^[a-z0-9_-]+$/.test(language));
   const grammars = await loadGrammars(languages);
 
-  highlight(codeBlocks, code => grammars.byLanguage[languageFor(code)], grammars.byScope);
+  highlight(codeBlocks, code => grammars.byLanguage[language(code)], grammars.byScope);
   return codeBlocks;
 };

--- a/src/language-aliases.js
+++ b/src/language-aliases.js
@@ -1,0 +1,15 @@
+export default {
+  docker: "dockerfile",
+  gql: "graphql",
+  js: "javascript",
+  jsx: "javascript",
+  md: "markdown",
+  py: "python",
+  rb: "ruby",
+  sass: "scss",
+  sh: "bash",
+  shell: "bash",
+  ts: "typescript",
+  yml: "yaml",
+  zsh: "bash"
+};

--- a/src/microlighter.js
+++ b/src/microlighter.js
@@ -1,4 +1,4 @@
-import { highlightAll } from "./index.js";
+import { highlightAll } from "./highlight-all.js";
 
 document.addEventListener("syntax-highlight", () => highlightAll());
 highlightAll();

--- a/test/build.spec.js
+++ b/test/build.spec.js
@@ -13,3 +13,23 @@ test("build emits matching unminified and minified auto-run bundles", async () =
   assert.match(minifiedBundle, /document\.addEventListener\(["']syntax-highlight["']/);
   assert.ok(bundle.length > minifiedBundle.length);
 });
+
+test("loads first-party language aliases outside the core bundle", async () => {
+  const [bundle, aliases] = await Promise.all([
+    readFile(new URL("../dist/microlighter.min.js", import.meta.url)),
+    readFile(new URL("../dist/language-aliases.js", import.meta.url), "utf8")
+  ]);
+
+  assert.doesNotMatch(bundle.toString(), /jsx:"javascript"/);
+  assert.match(aliases, /jsx:\s*"javascript"/);
+});
+
+test("exports the optional language alias map from the package", async () => {
+  const { default: languageAliases } = await import("microlighter/language-aliases");
+
+  assert.equal(languageAliases.js, "javascript");
+  assert.equal(languageAliases.ts, "typescript");
+  assert.equal(languageAliases.sass, "scss");
+  assert.equal(languageAliases.docker, "dockerfile");
+  assert.equal(languageAliases.gql, "graphql");
+});

--- a/test/fixtures/grammar-exhaustive.html
+++ b/test/fixtures/grammar-exhaustive.html
@@ -149,6 +149,12 @@ $keyword: #c792ea;
 SELECT id, scope FROM tokens
 WHERE start &gt;= 0
 LIMIT 10;</code></pre>
+    <pre><code class="language-svelte">&lt;script&gt;
+  let count = 0;
+&lt;/script&gt;
+{#if count &gt; 0}
+  &lt;button on:click={() =&gt; count++}&gt;Count: {count}&lt;/button&gt;
+{/if}</code></pre>
     <pre><code class="language-swift">struct Token {
     let scope: String
     var start = 0
@@ -167,6 +173,10 @@ rollup = "4.46.2"</code></pre>
 }
 
 const answer: number = 42;</code></pre>
+    <pre><code class="language-vue">&lt;script setup&gt;
+const count = ref(0)
+&lt;/script&gt;
+&lt;button @click="count++"&gt;Count: {{ count }}&lt;/button&gt;</code></pre>
     <pre><code class="language-yaml">name: CI
 on: [push]
 jobs:

--- a/test/grammar-dependencies.spec.js
+++ b/test/grammar-dependencies.spec.js
@@ -6,6 +6,7 @@ import {
   externalLanguagesFor,
   normalizeLanguage
 } from "../src/grammar-dependencies.js";
+import languageAliases from "../src/language-aliases.js";
 import cpp from "../src/grammars/cpp.js";
 import html from "../src/grammars/html.js";
 import markdown from "../src/grammars/markdown.js";
@@ -13,6 +14,8 @@ import objectiveC from "../src/grammars/objective-c.js";
 import scss from "../src/grammars/scss.js";
 import tsx from "../src/grammars/tsx.js";
 import typescript from "../src/grammars/typescript.js";
+import svelte from "../src/grammars/svelte.js";
+import vue from "../src/grammars/vue.js";
 
 test("finds external grammar languages in nested rules", () => {
   const grammar = {
@@ -31,7 +34,7 @@ test("finds external grammar languages in nested rules", () => {
     }
   };
 
-  assert.deepEqual([...externalLanguagesFor(grammar)], ["javascript", "yaml"]);
+  assert.deepEqual([...externalLanguagesFor(grammar)], ["js", "yaml"]);
 });
 
 test("recognizes source and text scopes but ignores unsupported includes", () => {
@@ -47,58 +50,43 @@ test("recognizes source and text scopes but ignores unsupported includes", () =>
 });
 
 test("normalizes language aliases and preserves canonical names", () => {
-  assert.equal(normalizeLanguage("js"), "javascript");
-  assert.equal(normalizeLanguage("yml"), "yaml");
-  assert.equal(normalizeLanguage("python"), "python");
-});
-
-test("normalizes aliases for the expanded grammar set", () => {
-  assert.equal(normalizeLanguage("c++"), "cpp");
-  assert.equal(normalizeLanguage("cc"), "cpp");
-  assert.equal(normalizeLanguage("cxx"), "cpp");
-  assert.equal(normalizeLanguage("h"), "c");
-  assert.equal(normalizeLanguage("hpp"), "cpp");
-  assert.equal(normalizeLanguage("cs"), "csharp");
-  assert.equal(normalizeLanguage("kt"), "kotlin");
-  assert.equal(normalizeLanguage("kts"), "kotlin");
-  assert.equal(normalizeLanguage("ps1"), "powershell");
-  assert.equal(normalizeLanguage("pwsh"), "powershell");
-  assert.equal(normalizeLanguage("gql"), "graphql");
-  assert.equal(normalizeLanguage("docker"), "dockerfile");
-  assert.equal(normalizeLanguage("xml"), "html");
-  assert.equal(normalizeLanguage("svg"), "html");
-  assert.equal(normalizeLanguage("webmanifest"), "json");
-  // tsx is now a genuine canonical grammar, not an alias to typescript.
-  assert.equal(normalizeLanguage("tsx"), "tsx");
-});
-
-test("normalizes aliases for the second expanded grammar set", () => {
-  assert.equal(normalizeLanguage("objc"), "objective-c");
-  assert.equal(normalizeLanguage("objectivec"), "objective-c");
-  assert.equal(normalizeLanguage("obj-c"), "objective-c");
-  assert.equal(normalizeLanguage("asm"), "assembly");
-  assert.equal(normalizeLanguage("nasm"), "assembly");
-  assert.equal(normalizeLanguage("x86asm"), "assembly");
-  assert.equal(normalizeLanguage("pl"), "perl");
-  assert.equal(normalizeLanguage("lua"), "lua");
-  assert.equal(normalizeLanguage("dart"), "dart");
-  assert.equal(normalizeLanguage("r"), "r");
+  assert.deepEqual(languageAliases, {
+    docker: "dockerfile",
+    gql: "graphql",
+    js: "javascript",
+    jsx: "javascript",
+    md: "markdown",
+    py: "python",
+    rb: "ruby",
+    sass: "scss",
+    sh: "bash",
+    shell: "bash",
+    ts: "typescript",
+    yml: "yaml",
+    zsh: "bash"
+  });
+  assert.equal(normalizeLanguage("jsx", languageAliases), "javascript");
+  assert.equal(normalizeLanguage("sass", languageAliases), "scss");
+  assert.equal(normalizeLanguage("python", languageAliases), "python");
 });
 
 test("reports dependencies used by the shipped grammars", () => {
   assert.deepEqual([...externalLanguagesFor(scss)], ["css"]);
   assert.deepEqual([...externalLanguagesFor(markdown)], ["yaml"]);
-  assert.deepEqual([...externalLanguagesFor(typescript)], ["javascript"]);
-  assert.deepEqual([...externalLanguagesFor(html)], ["css", "json", "javascript"]);
+  assert.deepEqual([...externalLanguagesFor(typescript)], ["js"]);
+  assert.deepEqual([...externalLanguagesFor(html)], ["css", "json", "js"]);
   assert.deepEqual([...externalLanguagesFor(cpp)], ["c"]);
-  assert.deepEqual([...externalLanguagesFor(tsx)], ["javascript", "typescript"]);
+  assert.deepEqual([...externalLanguagesFor(tsx)], ["js", "ts"]);
   assert.deepEqual([...externalLanguagesFor(objectiveC)], ["c"]);
+  assert.deepEqual(svelte.dependencies, ["html", "css", "scss", "javascript", "typescript"]);
+  assert.deepEqual(vue.dependencies, ["html", "css", "scss", "javascript", "typescript"]);
 });
 
 test("loads external dependencies once and indexes grammars by language and scope", async () => {
   const grammarFixtures = {
     html: {
       scopeName: "text.html",
+      dependencies: ["javascript"],
       patterns: [{ include: "source.js" }]
     },
     javascript: {
@@ -141,6 +129,14 @@ test("dynamically loads every new canonical grammar and transitively resolves it
   // tsx reuses TypeScript and JavaScript via external includes.
   assert.ok(loaded.byLanguage.javascript, "tsx should transitively load javascript");
   assert.ok(loaded.byLanguage.typescript, "tsx should transitively load typescript");
+});
+
+test("applies first-party aliases without caller configuration", async () => {
+  const load = createGrammarLoader();
+  const loaded = await load(["js"]);
+
+  assert.equal(loaded.byLanguage.js, loaded.byLanguage.javascript);
+  assert.equal(loaded.byScope.get("source.js"), loaded.byLanguage.javascript);
 });
 
 test("dynamically loads every second-batch canonical grammar and transitively resolves its dependencies", async () => {

--- a/test/grammar-exhaustive.spec.pw.js
+++ b/test/grammar-exhaustive.spec.pw.js
@@ -96,4 +96,26 @@ test.describe("Grammar exhaustive fixture (test/fixtures/grammar-exhaustive.html
     expect(diffHighlights.deleted).toEqual(expect.arrayContaining(["-const answer = 0;"]));
     expect(diffHighlights.keywords).toEqual([]);
   });
+
+  test("categorizes Svelte and Vue component syntax", async ({ page }) => {
+    await page.goto(FIXTURE, { waitUntil: "networkidle" });
+
+    const componentHighlights = await page.evaluate(() => {
+      const rangesFor = (language, category) => [...CSS.highlights.get(category) ?? []]
+        .filter(range => range.startContainer.parentElement?.closest(`code.language-${language}`))
+        .map(range => range.toString());
+
+      return {
+        svelteAttributes: rangesFor("svelte", "attribute-name"),
+        svelteKeywords: rangesFor("svelte", "keyword"),
+        vueAttributes: rangesFor("vue", "attribute-name"),
+        vueStorage: rangesFor("vue", "storage")
+      };
+    });
+
+    expect(componentHighlights.svelteAttributes).toContain("on:click");
+    expect(componentHighlights.svelteKeywords).toContain("if");
+    expect(componentHighlights.vueAttributes).toContain("@click");
+    expect(componentHighlights.vueStorage).toContain("const");
+  });
 });

--- a/test/highlight.spec.pw.js
+++ b/test/highlight.spec.pw.js
@@ -245,6 +245,44 @@ test.describe("MicroLighter demo site (docs/index.html)", () => {
     ]));
   });
 
+  test("accepts exported and custom language aliases through the import API", async ({ page }) => {
+    await page.goto(HOMEPAGE, { waitUntil: "networkidle" });
+
+    const highlighted = await page.evaluate(async () => {
+      const root = document.createElement("div");
+      root.innerHTML = [
+        '<pre><code id="exported-alias" class="language-jsx">const exported = true;</code></pre>',
+        '<pre><code id="custom-alias" class="language-ecmascript">const custom = true;</code></pre>'
+      ].join("");
+      document.body.append(root);
+
+      const { highlightAll } = await import("/docs/microlighter/index.js");
+      const { default: languageAliases } =
+        await import("/docs/microlighter/language-aliases.js");
+      await highlightAll({
+        root,
+        languageAliases: {
+          ...languageAliases,
+          ecmascript: "javascript"
+        }
+      });
+
+      const ids = new Set();
+      for (const highlight of CSS.highlights.values()) {
+        for (const range of highlight) {
+          const id = range.startContainer.parentElement?.closest("code")?.id;
+          if (id) ids.add(id);
+        }
+      }
+      return [...ids];
+    });
+
+    expect(highlighted).toEqual(expect.arrayContaining([
+      "exported-alias",
+      "custom-alias"
+    ]));
+  });
+
   test("removes stale ranges when code blocks disappear", async ({ page }) => {
     await page.goto(HOMEPAGE, { waitUntil: "networkidle" });
 


### PR DESCRIPTION
## Summary
- load first-party Markdown language aliases from a cached chunk
- add Svelte and Vue grammars with embedded language support
- keep the core bundle at 2.03 KiB gzip and tighten its size budget
- update documentation, homepage stats, and exhaustive browser coverage

## Testing
- npm test