### PR TITLE
docs: update to reflect `dist` folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ await highlightAll({
 Import the auto runner to highlight the page as soon as the module loads:
 
 ```html
-<link rel="stylesheet" href="./node_modules/microlighter/themes/github.css">
-<script type="module" src="./node_modules/microlighter/microlighter.min.js"></script>
+<link rel="stylesheet" href="./node_modules/microlighter/dist/themes/github.css">
+<script type="module" src="./node_modules/microlighter/dist/microlighter.min.js"></script>
 
 <body data-syntax-theme="github">
 ```
@@ -103,8 +103,8 @@ The event can also bubble from a code block or one of its parents.
 Use the auto runner directly from a CDN:
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/microlighter@2/themes/github.css">
-<script type="module" src="https://cdn.jsdelivr.net/npm/microlighter@2/microlighter.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/microlighter@2/dist/themes/github.css">
+<script type="module" src="https://cdn.jsdelivr.net/npm/microlighter@2/dist/microlighter.min.js"></script>
 
 <body data-syntax-theme="github">
   <pre><code class="language-javascript">const answer = 42;</code></pre>
@@ -116,8 +116,8 @@ Use the auto runner directly from a CDN:
 Import the optional `<micro-lighter>` custom element:
 
 ```html
-<link rel="stylesheet" href="./node_modules/microlighter/themes/github.css">
-<script type="module" src="./node_modules/microlighter/micro-lighter-element.min.js"></script>
+<link rel="stylesheet" href="./node_modules/microlighter/dist/themes/github.css">
+<script type="module" src="./node_modules/microlighter/dist/micro-lighter-element.min.js"></script>
 
 <body data-syntax-theme="github">
   <micro-lighter language="javascript" controls="copy" line-numbers>
@@ -186,7 +186,7 @@ Load one theme and set the matching `data-syntax-theme` value on `<body>` or
 any container:
 
 ```html
-<link rel="stylesheet" href="./node_modules/microlighter/themes/night-owl.css">
+<link rel="stylesheet" href="./node_modules/microlighter/dist/themes/night-owl.css">
 
 <section data-syntax-theme="night-owl">
   <!-- code blocks -->


### PR DESCRIPTION
## What does this change?

Was trying to use the remote package and it wasn't working. For example, this was the documented URL for a theme:

https://cdn.jsdelivr.net/npm/microlighter@2/themes/github.css

But that doesn't load anything. It looks like all the assets are in `dist` so that URL needs to account for that

https://cdn.jsdelivr.net/npm/microlighter@2/dist/themes/github.css

Presumably the ones for `node_modules` are needed too, as that's how the package is installed?

<img width="304" height="228" alt="CleanShot 2026-08-19 at 12 26 07@2x" src="https://github.com/user-attachments/assets/5a7cf074-8e8a-42bf-b76d-8d52933c9cbf" />


## Checklist

- [x] `npm test` passes locally
- [x] The size budget still passes (note any size impact below)
- [x] Added/updated tests or the demo (`docs/index.html`) if behavior changed
- [x] For a new grammar/theme, followed the steps in `CONTRIBUTING.md`