### PR TITLE
Added gruvbox theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Bundled themes:
 - `cobalt2`
 - `dracula`
 - `github`
+- `gruvbox`
 - `min`
 - `monokai`
 - `night-owl`

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,6 +44,7 @@
   <link rel="stylesheet" data-href="./microlighter/themes/min.css" data-syntax-theme="min" disabled>
   <link rel="stylesheet" data-href="./microlighter/themes/cobalt2.css" data-syntax-theme="cobalt2" disabled>
   <link rel="stylesheet" data-href="./microlighter/themes/tokyo-night.css" data-syntax-theme="tokyo-night" disabled>
+  <link rel="stylesheet" data-href="./microlighter/themes/gruvbox.css" data-syntax-theme="gruvbox" disabled>
   <script>setSyntaxTheme(document.documentElement.dataset.syntaxTheme);</script>
   <link rel="stylesheet" href="./global.css">
 </head>
@@ -77,6 +78,7 @@
           <option value="min">Min</option>
           <option value="cobalt2">Cobalt2</option>
           <option value="tokyo-night">Tokyo Night</option>
+          <option value="gruvbox">Gruvbox</option>
         </select>
       </label>
       <div class="theme-actions">

--- a/src/themes/gruvbox.css
+++ b/src/themes/gruvbox.css
@@ -1,0 +1,74 @@
+/* Reference: Gruvbox by morhetz — https://github.com/morhetz/gruvbox */
+[data-syntax-theme="gruvbox"] {
+  --syntax-background: light-dark(#fbf1c7, #282828);
+  --syntax-foreground: light-dark(#3c3836, #ebdbb2);
+  --syntax-comment: light-dark(#928374, #928374);
+  --syntax-keyword: light-dark(#9d0006, #fb4934);
+  --syntax-operator: light-dark(#076678, #8ec07c);
+  --syntax-string: light-dark(#79740e, #b8bb26);
+  --syntax-constant: light-dark(#af3a03, #fe8019);
+  --syntax-function: light-dark(#427b58, #fabd2f);
+  --syntax-type: light-dark(#8f3f71, #d3869b);
+  --syntax-variable: light-dark(#3c3836, #ebdbb2);
+  --syntax-property: light-dark(#076678, #83a598);
+  --syntax-tag: light-dark(#9d0006, #fb4934);
+  --syntax-selector: light-dark(#427b58, #83a598);
+  --syntax-inserted: light-dark(#79740e, #b8bb26);
+  --syntax-deleted: light-dark(#9d0006, #fb4934);
+
+  color-scheme: light dark;
+}
+
+[data-syntax-theme="gruvbox"] pre:has(code) {
+  background-color: var(--syntax-background);
+  color: var(--syntax-foreground);
+}
+
+::highlight(comment),
+::highlight(quote) { color: var(--syntax-comment); }
+
+::highlight(keyword),
+::highlight(storage),
+::highlight(at-rule),
+::highlight(doctype),
+::highlight(important),
+::highlight(section) { color: var(--syntax-keyword); }
+
+::highlight(operator),
+::highlight(punctuation) { color: var(--syntax-operator); }
+
+::highlight(string),
+::highlight(regexp),
+::highlight(attribute-value),
+::highlight(link),
+::highlight(raw) { color: var(--syntax-string); }
+
+::highlight(numeric),
+::highlight(boolean),
+::highlight(constant),
+::highlight(symbol),
+::highlight(character-entity),
+::highlight(anchor),
+::highlight(entity) { color: var(--syntax-constant); }
+
+::highlight(function),
+::highlight(decorator),
+::highlight(animation) { color: var(--syntax-function); }
+
+::highlight(type),
+::highlight(support) { color: var(--syntax-type); }
+
+::highlight(variable),
+::highlight(interpolation) { color: var(--syntax-variable); }
+
+::highlight(property),
+::highlight(key),
+::highlight(attribute-name) { color: var(--syntax-property); }
+
+::highlight(tag) { color: var(--syntax-tag); }
+
+::highlight(selector) { color: var(--syntax-selector); }
+
+::highlight(inserted) { color: var(--syntax-inserted); }
+
+::highlight(deleted) { color: var(--syntax-deleted); }

--- a/src/themes/index.css
+++ b/src/themes/index.css
@@ -9,3 +9,4 @@
 @import "./min.css";
 @import "./cobalt2.css";
 @import "./tokyo-night.css";
+@import "./gruvbox.css";


### PR DESCRIPTION
## What does this change?

Added the [gruvbox theme](https://github.com/morhetz/gruvbox). This is not a fully necessary change, but I figured I would contribute it, and let you decide if you want it or not. 

## Checklist

- [x] `npm test` passes locally
- [x] The size budget still passes (note any size impact below)
- [x] Added/updated tests or the demo (`docs/index.html`) if behavior changed
- [x] For a new grammar/theme, followed the steps in `CONTRIBUTING.md`

## Size impact

```
          themes\gruvbox.css   1.97 KiB  0.58 KiB
              themes\min.css   1.96 KiB  0.55 KiB

Average chunk size

  category  files  raw (min)      gzip
  --------  -----  ---------  --------
  grammars     37   1.69 KiB  0.73 KiB
    themes     11   1.97 KiB  0.56 KiB

Budget: dist/microlighter.min.js gzip 2.05 KiB / 2.05 KiB (ok)
```

On my most recent run it claims that it's under the budget, but other runs while editing said it exceeded it (see below)

```
  category  files  raw (min)      gzip
  --------  -----  ---------  --------
  grammars     37   1.69 KiB  0.72 KiB
    themes     11   1.97 KiB  0.56 KiB

Budget: dist/microlighter.min.js gzip 2.06 KiB / 2.05 KiB (OVER)

Size budget exceeded: dist/microlighter.min.js gzip is 2111 bytes, limit is 2100 bytes.
```

Again this is not a vital change, so if the budget is higher priority, maybe some sort of option for community contributed themes that don't involve bundling to the main repo might be a better solution (maybe a copy-paste showcase on the docs site instead?).