### PR TITLE
feat: add INI and nginx grammars

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ your markup stays clean and editable.
 
 - About 2 KiB compressed
 - No runtime dependencies
-- 35 languages, loaded on demand
+- 37 languages, loaded on demand
 - 10 bundled themes
 - Clean DOM with no token markup
 - Programmatic, automatic, and web component APIs
@@ -173,8 +173,8 @@ Custom aliases passed to `highlightAll()` must point to a bundled language.
 MicroLighter includes these grammars:
 
 `assembly`, `bash`, `c`, `cpp`, `csharp`, `css`, `dart`, `dockerfile`, `elixir`,
-`git-diff`, `go`, `graphql`, `heex`, `html`, `java`, `javascript`, `json`,
-`kotlin`, `lua`, `markdown`, `objective-c`, `perl`, `php`, `powershell`,
+`git-diff`, `go`, `graphql`, `heex`, `html`, `ini`, `java`, `javascript`, `json`,
+`kotlin`, `lua`, `markdown`, `nginx`, `objective-c`, `perl`, `php`, `powershell`,
 `python`, `r`, `ruby`, `rust`, `scss`, `sql`, `svelte`, `swift`, `toml`, `tsx`,
 `typescript`, `vue`, and `yaml`.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -399,6 +399,8 @@ export function YetAnotherTodoApp(): JSX.Element {
             <li data-lang="graphql">GraphQL</li>
             <li data-lang="dockerfile">Dockerfile</li>
             <li data-lang="git-diff">Git diff</li>
+            <li data-lang="ini">INI</li>
+            <li data-lang="nginx">nginx</li>
           </ul>
         </div>
       </div>
@@ -518,6 +520,13 @@ query GetToken($id: ID!) {
         <pre><code class="language-html">&lt;!-- A comment stays a comment --&gt;
 &lt;button type="button" aria-pressed="false"&gt;42&lt;/button&gt;</code></pre>
       </template>
+      <template data-lang="ini" data-label="INI">
+        <pre><code class="language-ini">; Application settings
+[server]
+port = 8080
+host = "localhost"
+ssl = true</code></pre>
+      </template>
       <template data-lang="java" data-label="Java">
         <pre><code class="language-java">public class Token {
     String scope = "keyword";
@@ -549,6 +558,16 @@ end</code></pre>
         <pre><code class="language-markdown"># MicroLighter
 
 A **tiny** syntax highlighter for the [CSS Custom Highlight API](https://developer.mozilla.org/).</code></pre>
+      </template>
+      <template data-lang="nginx" data-label="nginx">
+        <pre><code class="language-nginx">server {
+    listen 80;
+    server_name example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+    }
+}</code></pre>
       </template>
       <template data-lang="objective-c" data-label="Objective-C">
         <pre><code class="language-objective-c">@interface Token : NSObject

--- a/src/grammars/ini.js
+++ b/src/grammars/ini.js
@@ -1,0 +1,38 @@
+// Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/ini/syntaxes/ini.tmLanguage.json
+export default {
+    scopeName: "source.ini",
+    patterns: [
+        { include: "#comments" },
+        { include: "#section-headers" },
+        { include: "#key-value" },
+        { include: "#strings" },
+        { include: "#constants" },
+        { include: "#numbers" }
+    ],
+    repository: {
+        comments: { match: "^\\s*[;#].*$", name: "comment.line" },
+        "section-headers": {
+            match: "^\\s*\\[([^\\[\\]]+)\\]\\s*$",
+            captures: {
+                1: { name: "entity.name.section" }
+            }
+        },
+        "key-value": {
+            match: "^\\s*([^=;#\\s][^=;#]*?)\\s*(?==)",
+            captures: { 1: { name: "entity.name.key" } }
+        },
+        strings: {
+            patterns: [
+                { match: "'(?:\\\\.|[^'\\\\])*'", name: "string.quoted.single" },
+                { match: "\"(?:\\\\.|[^\"\\\\])*\"", name: "string.quoted.double" }
+            ]
+        },
+        constants: {
+            patterns: [
+                { match: "\\b(?:true|false|yes|no|on|off)\\b", name: "constant.language.boolean" },
+                { match: "\\b(?:null|none)\\b", name: "constant.language" }
+            ]
+        },
+        numbers: { match: "(?<![\\w.])[+-]?\\d+(?:\\.\\d+)?\\b", name: "constant.numeric" }
+    }
+};

--- a/src/grammars/ini.js
+++ b/src/grammars/ini.js
@@ -1,38 +1,51 @@
 // Reference: Microsoft VS Code (MIT) — https://github.com/microsoft/vscode/blob/main/extensions/ini/syntaxes/ini.tmLanguage.json
+// Comment rules rewritten without upstream's `(?!\G)` container (native JS RegExp lacks `\G`).
 export default {
-    scopeName: "source.ini",
-    patterns: [
-        { include: "#comments" },
-        { include: "#section-headers" },
-        { include: "#key-value" },
-        { include: "#strings" },
-        { include: "#constants" },
-        { include: "#numbers" }
-    ],
-    repository: {
-        comments: { match: "^\\s*[;#].*$", name: "comment.line" },
-        "section-headers": {
-            match: "^\\s*\\[([^\\[\\]]+)\\]\\s*$",
-            captures: {
-                1: { name: "entity.name.section" }
-            }
-        },
-        "key-value": {
-            match: "^\\s*([^=;#\\s][^=;#]*?)\\s*(?==)",
-            captures: { 1: { name: "entity.name.key" } }
-        },
-        strings: {
-            patterns: [
-                { match: "'(?:\\\\.|[^'\\\\])*'", name: "string.quoted.single" },
-                { match: "\"(?:\\\\.|[^\"\\\\])*\"", name: "string.quoted.double" }
-            ]
-        },
-        constants: {
-            patterns: [
-                { match: "\\b(?:true|false|yes|no|on|off)\\b", name: "constant.language.boolean" },
-                { match: "\\b(?:null|none)\\b", name: "constant.language" }
-            ]
-        },
-        numbers: { match: "(?<![\\w.])[+-]?\\d+(?:\\.\\d+)?\\b", name: "constant.numeric" }
+  scopeName: "source.ini",
+  patterns: [
+    {
+      begin: "#",
+      beginCaptures: { 0: { name: "punctuation.definition.comment.ini" } },
+      end: "\\n",
+      name: "comment.line.number-sign.ini"
+    },
+    {
+      begin: ";",
+      beginCaptures: { 0: { name: "punctuation.definition.comment.ini" } },
+      end: "\\n",
+      name: "comment.line.semicolon.ini"
+    },
+    {
+      match: "\\b([a-zA-Z0-9_.-]+)\\b\\s*(=)",
+      captures: {
+        1: { name: "keyword.other.definition.ini" },
+        2: { name: "punctuation.separator.key-value.ini" }
+      }
+    },
+    {
+      match: "^(\\[)(.*?)(\\])",
+      name: "entity.name.section.group-title.ini",
+      captures: {
+        1: { name: "punctuation.definition.entity.ini" },
+        3: { name: "punctuation.definition.entity.ini" }
+      }
+    },
+    {
+      begin: "'",
+      beginCaptures: { 0: { name: "punctuation.definition.string.begin.ini" } },
+      end: "'",
+      endCaptures: { 0: { name: "punctuation.definition.string.end.ini" } },
+      name: "string.quoted.single.ini",
+      patterns: [
+        { match: "\\\\.", name: "constant.character.escape.ini" }
+      ]
+    },
+    {
+      begin: "\"",
+      beginCaptures: { 0: { name: "punctuation.definition.string.begin.ini" } },
+      end: "\"",
+      endCaptures: { 0: { name: "punctuation.definition.string.end.ini" } },
+      name: "string.quoted.double.ini"
     }
+  ]
 };

--- a/src/grammars/nginx.js
+++ b/src/grammars/nginx.js
@@ -1,0 +1,44 @@
+// Reference: nginx configuration syntax conventions (community grammar style)
+export default {
+    scopeName: "source.nginx",
+    patterns: [
+        { include: "#comments" },
+        { include: "#directives" },
+        { include: "#block-delimiters" },
+        { include: "#variables" },
+        { include: "#strings" },
+        { include: "#numbers" },
+        { include: "#keywords" }
+    ],
+    repository: {
+        comments: { match: "#.*$", name: "comment.line.number-sign" },
+        directives: {
+            match: "^\\s*([A-Za-z_][\\w-]*)\\s*(?=\\S)",
+            captures: {
+                1: { name: "keyword.other.directive" }
+            }
+        },
+        "block-delimiters": {
+            match: "[{};]",
+            name: "punctuation.section.block"
+        },
+        variables: {
+            match: "\\$[A-Za-z_][\\w-]*|\\$\\{[^}]+\\}",
+            name: "variable.other"
+        },
+        strings: {
+            patterns: [
+                { match: "\"(?:\\\\.|[^\"\\\\])*\"", name: "string.quoted.double" },
+                { match: "'(?:\\\\.|[^'\\\\])*'", name: "string.quoted.single" }
+            ]
+        },
+        numbers: {
+            match: "(?<![\\w.])[-+]?\\d+(?:\\.\\d+)?(?:[kKmMgG]?)\\b",
+            name: "constant.numeric"
+        },
+        keywords: {
+            match: "\\b(?:on|off|yes|no|default|auto|none|http|https|tcp|udp|unix|listen|server_name|proxy_pass|root|index|rewrite|return|include|location|upstream|server)\\b",
+            name: "keyword"
+        }
+    }
+};

--- a/test/fixtures/grammar-exhaustive.html
+++ b/test/fixtures/grammar-exhaustive.html
@@ -92,6 +92,11 @@ query GetToken($id: ID!) {
 &lt;/.button&gt;</code></pre>
     <pre><code class="language-html">&lt;!-- A comment stays a comment --&gt;
 &lt;button type="button" aria-pressed="false"&gt;42&lt;/button&gt;</code></pre>
+    <pre><code class="language-ini">; Application settings
+[server]
+port = 8080
+host = "localhost"
+ssl = true</code></pre>&lt;button type="button" aria-pressed="false"&gt;42&lt;/button&gt;</code></pre>
     <pre><code class="language-java">public class Token {
     String scope = "keyword";
     int start = 0;
@@ -112,6 +117,14 @@ end</code></pre>
     <pre><code class="language-markdown"># MicroLighter
 
 A **tiny** syntax highlighter for the [CSS Custom Highlight API](https://developer.mozilla.org/).</code></pre>
+    <pre><code class="language-nginx">server {
+    listen 80;
+    server_name example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+    }
+}</code></pre>
     <pre><code class="language-objective-c">@interface Token : NSObject
 @property (nonatomic, strong) NSString *scope;
 @end</code></pre>


### PR DESCRIPTION
## What does this change?

Added 2 new gramar for INI and nginx files.

## Checklist

- [x] `npm test` passes locally
- [x] The size budget still passes (note any size impact below)
- [x] Added/updated tests or the demo (`docs/index.html`) if behavior changed
- [x] For a new grammar/theme, followed the steps in `CONTRIBUTING.md`

## Size impact

none
