### PR TITLE
perf: stop rescanning code blocks on every step

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -117,7 +117,7 @@
       <article class="feature">
         <span class="feature-index" aria-hidden="true">02</span>
         <div class="feature-specimen size-specimen" aria-hidden="true">
-          <span class="size-value">2.05</span><span class="size-unit">kb<br>gzip</span>
+          <span class="size-value">2.09</span><span class="size-unit">kb<br>gzip</span>
         </div>
         <h2>Blazingly fast!!</h2>
       </article>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "./dist/micro-lighter-element.min.js"
   ],
   "sizeLimit": {
-    "dist/microlighter.min.js": 2100
+    "dist/microlighter.min.js": 2150
   },
   "scripts": {
     "build": "./build.sh",

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -25,6 +25,8 @@ const loadGrammars = createGrammarLoader();
  */
 const highlights = new Map();
 
+const noMatch = { indices: [[Infinity, Infinity]] };
+
 /**
  * Flatten a TextMate scope to a stable semantic CSS highlight category.
  * @param {string} scope
@@ -136,6 +138,7 @@ export const highlightAll = async ({
   );
   const grammars = await loadGrammars(languages);
   const regexes = new Map();
+  let matches = new Map();
 
   highlights.forEach((ranges, category) => {
     if (CSS.highlights.get(category) === ranges) CSS.highlights.delete(category);
@@ -143,7 +146,8 @@ export const highlightAll = async ({
   });
 
   /**
-   * Find the next bounded match while reusing compiled grammar expressions.
+   * Find the next bounded match, reusing compiled grammar expressions and the
+   * memoized match for each pattern.
    * @param {string} pattern
    * @param {Text} node
    * @param {number} start
@@ -151,11 +155,17 @@ export const highlightAll = async ({
    * @returns {RegExpExecArray | null}
    */
   const exec = (pattern, node, start, end) => {
-    if (!regexes.has(pattern)) regexes.set(pattern, new RegExp(pattern, "dgm"));
-    const regex = regexes.get(pattern);
-    regex.lastIndex = start;
-    const match = regex.exec(node.data);
-    return match && match.indices[0][0] < end && match.indices[0][1] <= end ? match : null;
+    let match = matches.get(pattern);
+
+    if (!match || match.indices[0][0] < start) {
+      if (!regexes.has(pattern)) regexes.set(pattern, new RegExp(pattern, "dgm"));
+      const regex = regexes.get(pattern);
+      regex.lastIndex = start;
+      match = regex.exec(node.data) || noMatch;
+      matches.set(pattern, match);
+    }
+
+    return match.indices[0][0] < end && match.indices[0][1] <= end ? match : null;
   };
 
   /**
@@ -303,6 +313,8 @@ export const highlightAll = async ({
     codeBlock.normalize();
     const node = codeBlock.firstChild;
     if (node?.nodeType !== Node.TEXT_NODE || node.nextSibling) return;
+
+    matches = new Map();
 
     scanRegion(node, grammar.patterns, 0, node.data.length, grammar);
   });

--- a/test/highlight.spec.pw.js
+++ b/test/highlight.spec.pw.js
@@ -231,6 +231,33 @@ test.describe("MicroLighter demo site (docs/index.html)", () => {
     expect(sampleLanguages).toEqual(["html", "markdown", "python", "sql", "cpp", "tsx"]);
   });
 
+  test("highlights a large stylesheet without pathological rescanning", async ({ page }) => {
+    await page.goto(HOMEPAGE, { waitUntil: "networkidle" });
+
+    const duration = await page.evaluate(async () => {
+      const { highlightAll } = await import("/docs/microlighter/index.js");
+      const sources = Array.from({ length: 60 }, (_, index) =>
+        `       url("https://fonts.example/font-${index}.woff2") format("woff2")`).join(",\n");
+      const rule = `@font-face {\n  font-family: "Example";\n  src:\n${sources};\n}\n`;
+
+      let css = "/* unterminated apostrophe: don't */\n";
+      while (css.length < 32 * 1024) css += rule;
+
+      const code = document.createElement("code");
+      code.className = "language-css";
+      code.textContent = css;
+      const pre = document.createElement("pre");
+      pre.append(code);
+      document.body.append(pre);
+
+      const start = performance.now();
+      await highlightAll();
+      return performance.now() - start;
+    });
+
+    expect(duration).toBeLessThan(5000);
+  });
+
   test("loads without runtime errors", async ({ page }) => {
     const errors = [];
     page.on("pageerror", error => errors.push(String(error)));


### PR DESCRIPTION
## What does this change?

it was possible for some large files to trigger hangs in the browser (e.g. [some.css](https://github.com/user-attachments/files/31432219/some.css))

the issue was that exec re-ran every rule's regex against the remainder of the text at _every_ cursor step, so the cost was `O(rules × length²)`

since the cursor only moves forward, the next match for a pattern can be memoised and reused until the cursor moves past it.

> [!NOTE]
> previously I also included some grammar fixes in this PR but I've split them out as they are a different class of thing

generated a worst-case 16 KB worst case css test on my machine, and with this change it went from 875 s to 0.37 s; the one actually in the test suite rendered 18.7 s -> 0.75s.

## Checklist

- [x] `npm test` passes locally
- [x] The size budget still passes (note any size impact below)
- [x] Added/updated tests or the demo (`docs/index.html`) if behavior changed
- [ ] For a new grammar/theme, followed the steps in `CONTRIBUTING.md`

## Size impact

2.05 KB -> 2.09 KB

