### PR TITLE
custom element page improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,7 @@ ranges live in the CSS Custom Highlight registry.
    the `::highlight(...)` categories. Use existing themes as a template.
 2. Add an `@import` for it in `src/themes/index.css`.
 3. Add the theme to the `<select>` in `docs/index.html`.
+4. Add the theme to the `<select>` in `docs/icustom-element.html`.
 
 Keep page-chrome styling (backgrounds, borders) out of theme files — themes
 should only define syntax colors. The demo page derives its own chrome.

--- a/docs/custom-element.html
+++ b/docs/custom-element.html
@@ -368,7 +368,6 @@ micro-lighter::part(line-numbers) {
       setColorScheme(document.documentElement.dataset.colorScheme === "dark" ? "light" : "dark");
     });
     function reRenderExample(){
-      console.log("hi")
       document.getElementById("themed-example").innerHTML = `&lt;html data-syntax-theme="${themeSelect.value}"&gt;
   &lt;head&gt;
     &lt;link rel="stylesheet" href="./microlighter/themes/${themeSelect.value}.css"&gt;

--- a/docs/custom-element.html
+++ b/docs/custom-element.html
@@ -44,6 +44,7 @@
   <link rel="stylesheet" data-href="./microlighter/themes/min.css" data-syntax-theme="min" disabled>
   <link rel="stylesheet" data-href="./microlighter/themes/cobalt2.css" data-syntax-theme="cobalt2" disabled>
   <link rel="stylesheet" data-href="./microlighter/themes/tokyo-night.css" data-syntax-theme="tokyo-night" disabled>
+  <link rel="stylesheet" data-href="./microlighter/themes/gruvbox.css" data-syntax-theme="gruvbox" disabled>
   <script>setSyntaxTheme(document.documentElement.dataset.syntaxTheme);</script>
   <link rel="stylesheet" href="./global.css">
   <style>
@@ -192,7 +193,7 @@
     <div class="theme-controls">
       <label class="theme-control">
         Syntax theme
-        <select id="theme">
+        <select id="theme" onchange="reRenderExample()">
           <button>
             <selectedcontent></selectedcontent>
             <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9l6 6l6-6"/></svg>
@@ -207,6 +208,7 @@
           <option value="min">Min</option>
           <option value="cobalt2">Cobalt2</option>
           <option value="tokyo-night">Tokyo Night</option>
+          <option value="gruvbox">Gruvbox</option>
         </select>
       </label>
       <div class="theme-actions">
@@ -239,7 +241,8 @@
       </div>
       <div class="install-steps">
         <p>Load a theme, set its scope wherever it belongs on your page, and import the custom element.</p>
-        <pre><code class="language-html">&lt;html data-syntax-theme="github"&gt;
+        <micro-lighter language="html" controls="copy">
+          <pre><code id="themed-example">&lt;html data-syntax-theme="github"&gt;
   &lt;head&gt;
     &lt;link rel="stylesheet" href="./microlighter/themes/github.css"&gt;
     &lt;script type="module" src="./microlighter/micro-lighter-element.min.js"&gt;&lt;/script&gt;
@@ -251,6 +254,7 @@
     &lt;/micro-lighter&gt;
   &lt;/body&gt;
 &lt;/html&gt;</code></pre>
+        </micro-lighter>
       </div>
     </section>
 
@@ -363,6 +367,21 @@ micro-lighter::part(line-numbers) {
     colorSchemeToggle.addEventListener("click", () => {
       setColorScheme(document.documentElement.dataset.colorScheme === "dark" ? "light" : "dark");
     });
+    function reRenderExample(){
+      console.log("hi")
+      document.getElementById("themed-example").innerHTML = `&lt;html data-syntax-theme="${themeSelect.value}"&gt;
+  &lt;head&gt;
+    &lt;link rel="stylesheet" href="./microlighter/themes/${themeSelect.value}.css"&gt;
+    &lt;script type="module" src="./microlighter/micro-lighter-element.min.js"&gt;&lt;/script&gt;
+  &lt;/head&gt;
+
+  &lt;body&gt;
+    &lt;micro-lighter language="javascript" controls="copy" line-numbers&gt;
+      &lt;pre&gt;&lt;code&gt;customElements.define("spicy-iframe", class extends HTMLElement {});&lt;/code&gt;&lt;/pre&gt;
+    &lt;/micro-lighter&gt;
+  &lt;/body&gt;
+&lt;/html&gt;`
+    }
   </script>
   <script type="module" src="./microlighter/micro-lighter-element.min.js"></script>
 </body>

--- a/test/custom-element.spec.pw.js
+++ b/test/custom-element.spec.pw.js
@@ -4,8 +4,8 @@ test.describe("MicroLighter custom element", () => {
   test("renders the custom element demo page", async ({ page }) => {
     await page.goto("/docs/custom-element.html", { waitUntil: "networkidle" });
 
-    await expect(page.locator("micro-lighter")).toHaveCount(3);
-    await expect(page.getByRole("button", { name: "Copy" })).toHaveCount(3);
+    await expect(page.locator("micro-lighter")).toHaveCount(4);
+    await expect(page.getByRole("button", { name: "Copy" })).toHaveCount(4);
 
     await expect.poll(() => page.evaluate(() => {
       let total = 0;


### PR DESCRIPTION
## What does this change?

This change does 4 things:

1. Update the current `custom-elements.html` page with missing themes
2. Adds a message to the CONTRIBUTING.md to tell people to update that page when adding themes
3. Adds `micro-lighter` to the example on `custom-elements.html`
4. Makes the first example reactive to your theme choice (see gif below)

<img width="1969" height="902" alt="msedge_sMlnZpvW8f" src="https://github.com/user-attachments/assets/3664e93e-7a5b-4b54-a0e6-60f41df9150f" />


## Checklist

- [x] `npm test` passes locally
- [x] The size budget still passes (note any size impact below)
- [x] Added/updated tests or the demo (`docs/index.html`) if behavior changed
- [x] For a new grammar/theme, followed the steps in `CONTRIBUTING.md`

## Size impact

None
