### PR TITLE
feat: add support to astro syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Custom aliases passed to `highlightAll()` must point to a bundled language.
 
 MicroLighter includes these grammars:
 
-`assembly`, `bash`, `c`, `cpp`, `csharp`, `css`, `dart`, `dockerfile`, `elixir`,
+`assembly`, `astro`, `bash`, `c`, `cpp`, `csharp`, `css`, `dart`, `dockerfile`, `elixir`,
 `git-diff`, `go`, `graphql`, `heex`, `html`, `java`, `javascript`, `json`,
 `kotlin`, `lua`, `markdown`, `objective-c`, `perl`, `php`, `powershell`,
 `python`, `r`, `ruby`, `rust`, `scss`, `sql`, `svelte`, `swift`, `toml`, `tsx`,

--- a/docs/index.html
+++ b/docs/index.html
@@ -352,6 +352,7 @@ export function YetAnotherTodoApp(): JSX.Element {
             <li data-lang="javascript">JavaScript</li>
             <li data-lang="typescript">TypeScript</li>
             <li data-lang="tsx">TSX</li>
+            <li data-lang="astro">Astro</li>
             <li data-lang="svelte">Svelte</li>
             <li data-lang="vue">Vue</li>
             <li data-lang="heex">HEEx</li>
@@ -431,6 +432,17 @@ section .text
 _start:
     mov eax, 1
     int 0x80</code></pre>
+      </template>
+      <template data-lang="astro" data-label="Astro">
+        <pre><code class="language-astro">---
+const greeting = "Hello";
+---
+
+&lt;h1&gt;{greeting}, World!&lt;/h1&gt;
+
+&lt;style&gt;
+  h1 { color: royalblue; }
+&lt;/style&gt;</code></pre>
       </template>
       <template data-lang="bash" data-label="Bash">
         <pre><code class="language-bash">#!/usr/bin/env bash

--- a/src/grammars/astro.js
+++ b/src/grammars/astro.js
@@ -1,0 +1,72 @@
+// Reference: Astro Language Tools (MIT) - https://github.com/withastro/astro/tree/HEAD/packages/language-tools/vscode/syntaxes/astro.tmLanguage.json
+export default {
+  scopeName: "source.astro",
+  dependencies: ["html", "css", "scss", "javascript", "typescript", "tsx"],
+  patterns: [
+    { include: "#frontmatter" },
+    { include: "#script" },
+    { include: "#style" },
+    { include: "#interpolation" },
+    { include: "text.html.basic" }
+  ],
+  repository: {
+    frontmatter: {
+      begin: "^---\\s*$",
+      end: "^---\\s*$",
+      beginCaptures: {
+        0: { name: "punctuation.definition.frontmatter.begin.astro" }
+      },
+      endCaptures: {
+        0: { name: "punctuation.definition.frontmatter.end.astro" }
+      },
+      contentName: "meta.embedded.block.astro",
+      patterns: [{ include: "source.ts" }]
+    },
+    script: {
+      patterns: [
+        {
+          begin: "<(script)\\s*>",
+          end: "</(script)\\s*>",
+          beginCaptures: {
+            1: { name: "entity.name.tag" }
+          },
+          endCaptures: {
+            1: { name: "entity.name.tag" }
+          },
+          contentName: "source.ts.embedded.astro",
+          patterns: [{ include: "source.ts" }]
+        },
+        { include: "text.html.basic#embedded-javascript" }
+      ]
+    },
+    style: {
+      patterns: [
+        {
+          begin: "<(style)\\b(?=[^>]*\\blang\\s*=\\s*(['\"])scss\\2)[^>]*>",
+          end: "</(style)\\s*>",
+          beginCaptures: {
+            1: { name: "entity.name.tag" }
+          },
+          endCaptures: {
+            1: { name: "entity.name.tag" }
+          },
+          contentName: "source.scss.embedded.astro",
+          patterns: [{ include: "source.scss" }]
+        },
+        { include: "source.css" }
+      ]
+    },
+    interpolation: {
+      begin: "\\{",
+      end: "\\}",
+      beginCaptures: {
+        0: { name: "punctuation.section.embedded.begin.astro" }
+      },
+      endCaptures: {
+        0: { name: "punctuation.section.embedded.end.astro" }
+      },
+      contentName: "meta.embedded.expression.astro",
+      patterns: [{ include: "text.html.basic#comments" }, { include: "source.tsx" }]
+    }
+  }
+};

--- a/test/fixtures/grammar-exhaustive.html
+++ b/test/fixtures/grammar-exhaustive.html
@@ -28,6 +28,15 @@ section .text
 _start:
     mov eax, 1
     int 0x80</code></pre>
+    <pre><code class="language-astro">---
+const greeting = "Hello";
+---
+
+&lt;h1&gt;{greeting}, World!&lt;/h1&gt;
+
+&lt;style&gt;
+  h1 { color: royalblue; }
+&lt;/style&gt;</code></pre>
     <pre><code class="language-bash">#!/usr/bin/env bash
 set -euo pipefail
 


### PR DESCRIPTION
## What does this change?

This PR adds a new grammar to support `.astro` file syntax based on the [Astro Language Tools syntax definition](https://github.com/withastro/astro/tree/HEAD/packages/language-tools/vscode/syntaxes/markdown.astro.tmLanguage.json), and reuses MicroLighter's existing HTML, CSS, SCSS, TypeScript and TSX grammars for embedded content.

Astro files combine a TypeScript frontmatter section with an HTML/JSX-like template, where expressions can be embedded directly in markup and `<script>` and `<style>` blocks can contain JavaScript or TypeScript, CSS or SCSS respectively.

This grammar includes:
- Astro frontmatter.
- `<script>` and `<style>` blocks.
- Interpolations.
- Embedded HTML/CSS/SCSS/TypeScript/TSX syntax.

Other reference:
- [SYNTAX_SPEC.md](https://github.com/withastro/compiler-rs/blob/feat/rust/docs/SYNTAX_SPEC.md)

Playground preview:

<img width="479" height="388" alt="image" src="https://github.com/user-attachments/assets/3d757f2d-4854-49d9-9bcd-0054819610b4" />

## Checklist

- [x] `npm test` passes locally
- [x] The size budget still passes (note any size impact below)
- [x] Added/updated tests or the demo (`docs/index.html`) if behavior changed
- [x] For a new grammar/theme, followed the steps in `CONTRIBUTING.md`

## Size impact

```text
Bundles
                               file       raw      gzip    brotli
  ---------------------------------  --------  --------  --------
           dist/microlighter.min.js  4.52 KiB  2.09 KiB  1.91 KiB
  dist/micro-lighter-element.min.js  8.81 KiB  3.59 KiB  3.17 KiB

Lazy-loaded chunks (fetched on demand)

                        file  raw (min)      gzip
  --------------------------  ---------  --------
           grammars/astro.js   1.61 KiB  0.49 KiB

Average chunk size

  category  files  raw (min)      gzip
  --------  -----  ---------  --------
  grammars     38   1.69 KiB  0.73 KiB

Budget: dist/microlighter.min.js gzip 2.09 KiB / 2.10 KiB (ok)
```